### PR TITLE
Improve the Makefile, including a new 'check' target that runs gometalinter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: go
 go:
   - '1.10'
 install:
-  - go get github.com/golang/dep/cmd/dep
+  - make tools
 script:
   - make release
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-.PHONY: clean deps update_deps docs_server release all changelog
-
 CONCH_VERSION="0.2.1"
 CONCH_BUILD_TIME=`date +%s`
 CONCH_GIT_REV=`git describe --always --abbrev --dirty`
@@ -10,35 +8,30 @@ BUILD_ARGS = -ldflags="-X main.Version=${CONCH_VERSION} -X main.BuildTime=${CONC
 
 BUILD = go build ${BUILD_ARGS} 
 
-BINARIES = bin/conch
+default: clean check bin/conch ## By default, run 'clean', 'check', 'bin/conch'
 
-ifneq ($(UNAME_S), SunOS)
-BINARIES += bin/conch-mbo
-endif
+first-run: tools ## Install all the dependencies needed to build and test
 
-all: ${BINARIES}
-
-bin/conch: pkg/**/*.go cmd/conch/*.go vendor
+.PHONY: bin/conch
+bin/conch: pkg/**/*.go cmd/conch/*.go vendor ## Build bin/conch
+	@echo "==> building bin/conch"
 	${BUILD} -o bin/conch cmd/conch/conch.go
 
-bin/conch-mbo: pkg/**/*.go cmd/conch-mbo/*.go vendor
+.PHONY: bin/conch-mbo
+bin/conch-mbo: pkg/**/*.go cmd/conch-mbo/*.go vendor ## Build bin/conch-mbo
 	${BUILD} -o bin/conch-mbo cmd/conch-mbo/conch-mbo.go
 
-clean: 
+clean: ## Remove build products from build/
 	rm -f bin/conch bin/conch-mbo
 
-vendor: deps
-
-deps:
+vendor: ## Install dependencies
 	dep ensure -v -vendor-only
 
-update_deps:
+update_deps: ## Update dependencies
 	dep ensure -update -v
 
-docs_server:
-	godoc -http=:6060 -v -goroot ./
-
-release: vendor
+.PHONY: release
+release: vendor check ## Build binaries for all supported platforms
 	GOOS=darwin GOARCH=amd64 ${BUILD} -o release/conch-mbo-darwin-amd64 cmd/conch-mbo/conch-mbo.go
 	GOOS=darwin GOARCH=amd64 ${BUILD} -o release/conch-darwin-amd64 cmd/conch/conch.go
 	GOOS=linux GOARCH=amd64 ${BUILD} -o release/conch-linux-amd64 cmd/conch/conch.go
@@ -49,3 +42,36 @@ release: vendor
 # gem install github_changelog_generator
 changelog:
 	github_changelog_generator -u joyent -p conch-shell #--due-tag ${CONCH_VERSION}
+
+.PHONY: check
+check: ## Ensure that code matchs best practices
+	@echo "==> Checking for best practices"
+	gometalinter \
+		--deadline 10m \
+		--vendor \
+		--sort="path" \
+		--aggregate \
+		--enable-gc \
+		--disable-all \
+		--enable vet \
+		--enable deadcode \
+		--enable varcheck \
+		--enable ineffassign \
+		--enable gofmt \
+		./...
+#		--enable goimports \
+#		--enable misspell \
+
+
+tools: ## Download and install all dev/code tools
+	@echo "==> Installing dev tools"
+	go get -u github.com/golang/dep/cmd/dep
+	go get -u github.com/alecthomas/gometalinter
+	gometalinter --install
+
+
+.PHONY: help
+help: ## Display this help message
+	@echo "GNU make(1) targets:"
+	@grep -E '^[a-zA-Z_.-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,11 @@ bin/conch: pkg/**/*.go cmd/conch/*.go vendor ## Build bin/conch
 
 .PHONY: bin/conch-mbo
 bin/conch-mbo: pkg/**/*.go cmd/conch-mbo/*.go vendor ## Build bin/conch-mbo
+	@echo "==> building bin/conch-mbo"
 	${BUILD} -o bin/conch-mbo cmd/conch-mbo/conch-mbo.go
 
-clean: ## Remove build products from build/
+clean: ## Remove build products from bin/
+	@echo "==> Removing build products from bin/"
 	rm -f bin/conch bin/conch-mbo
 
 vendor: ## Install dependencies
@@ -32,6 +34,7 @@ update_deps: ## Update dependencies
 
 .PHONY: release
 release: vendor check ## Build binaries for all supported platforms
+	@echo "==> Building for all the platforms"
 	GOOS=darwin GOARCH=amd64 ${BUILD} -o release/conch-mbo-darwin-amd64 cmd/conch-mbo/conch-mbo.go
 	GOOS=darwin GOARCH=amd64 ${BUILD} -o release/conch-darwin-amd64 cmd/conch/conch.go
 	GOOS=linux GOARCH=amd64 ${BUILD} -o release/conch-linux-amd64 cmd/conch/conch.go

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 * Run `go get github.com/joyent/conch-shell`
 * The code will end up in `$GOPATH/src/github.com/joyent/conch-shell`
 
+## Install build dependencies
+
+* Run `make first-run`
+* See also `make help`
+
 ## Building
 
 * Install [dep](https://golang.github.io/dep/docs/installation.html)

--- a/README.md
+++ b/README.md
@@ -28,14 +28,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   * `export GOPATH=$(go env GOPATH); export PATH="$GOPATH/bin:$PATH"`
   * Typically, `$GOPATH` is `~/go` but it doesn't have to be. Mine is
     `~/src/go`. The important part is the layout underneath `$GOPATH`
-* Add the following incantation to `~/.gitconfig` which will cause `go get` to
-  use ssh to access github rather than https. That's necessary for private repos
-  like this one.
-
-```
-[url "git@github.com:"]
-	insteadOf = https://github.com/
-```
 
 ## Check out the code
 


### PR DESCRIPTION
This adds a few new makefile targets, listed below. Most importantly, it adds a new target that runs gometalinter, including inside travis.

Also, when running 'make', the new default run list is 'clean', 'check', 'bin/conch'

Added:
- help
- tools
- check

( This steals a lot of its smarts from https://github.com/joyent/triton-go )