### PR TITLE
feat: Commands to manage Validations and Validation Plans

### DIFF
--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -13,6 +13,7 @@ import (
 	"github.com/joyent/conch-shell/pkg/commands/internal/profile"
 	"github.com/joyent/conch-shell/pkg/commands/internal/relay"
 	"github.com/joyent/conch-shell/pkg/commands/internal/user"
+	"github.com/joyent/conch-shell/pkg/commands/internal/validation"
 	"github.com/joyent/conch-shell/pkg/commands/internal/workspaces"
 	"gopkg.in/jawher/mow.cli.v1"
 )
@@ -25,4 +26,5 @@ func Init(app *cli.Cli) {
 	relay.Init(app)
 	user.Init(app)
 	workspaces.Init(app)
+	validation.Init(app)
 }

--- a/pkg/commands/internal/validation/init.go
+++ b/pkg/commands/internal/validation/init.go
@@ -35,7 +35,7 @@ func Init(app *cli.Cli) {
 			cmd.Before = func() {
 				util.BuildAPIAndVerifyLogin()
 				var err error
-				validationUUID, err = uuid.FromString(*validationPlanID)
+				validationUUID, err = util.MagicValidationPlanID(*validationPlanID)
 				if err != nil {
 					util.Bail(err)
 				}
@@ -80,7 +80,7 @@ func Init(app *cli.Cli) {
 			cmd.Before = func() {
 				util.BuildAPIAndVerifyLogin()
 				var err error
-				validationPlanUUID, err = uuid.FromString(*validationPlanID)
+				validationPlanUUID, err = util.MagicValidationPlanID(*validationPlanID)
 				if err != nil {
 
 					util.Bail(err)

--- a/pkg/commands/internal/validation/init.go
+++ b/pkg/commands/internal/validation/init.go
@@ -1,0 +1,88 @@
+// Copyright 2018 Joyent, Inc.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package validation contains commands for validation related commands
+package validation
+
+import (
+	"github.com/joyent/conch-shell/pkg/util"
+	"gopkg.in/jawher/mow.cli.v1"
+	uuid "gopkg.in/satori/go.uuid.v1"
+)
+
+var validationPlanUUID uuid.UUID
+
+// Init loads up the commands dealing with validations and validation plans
+func Init(app *cli.Cli) {
+	app.Command(
+		"validations vs",
+		"List available validations",
+		getValidations,
+	)
+	app.Command(
+		"validation-plans vps",
+		"Manage validation plans",
+		func(cmd *cli.Cmd) {
+			cmd.Before = func() {
+				util.BuildAPIAndVerifyLogin()
+			}
+			cmd.Command(
+				"get",
+				"List all active validation plans",
+				getValidationPlans,
+			)
+			cmd.Command(
+				"create",
+				"Create a new validation plan",
+				createValidationPlan,
+			)
+		},
+	)
+	app.Command(
+		"validation-plan vp",
+		"Commands for operating on a validation plan",
+		func(cmd *cli.Cmd) {
+
+			var validationPlanID = cmd.StringArg("ID", "", "The UUID of the validation plan")
+
+			cmd.Spec = "ID"
+
+			cmd.Before = func() {
+				util.BuildAPIAndVerifyLogin()
+				var err error
+				validationPlanUUID, err = uuid.FromString(*validationPlanID)
+				if err != nil {
+
+					util.Bail(err)
+				}
+				return
+			}
+
+			cmd.Command(
+				"get",
+				"Get details of a validation plan",
+				getValidationPlan,
+			)
+
+			cmd.Command(
+				"validations",
+				"Show a validation plan's associated validations",
+				showValidationPlanValidations,
+			)
+
+			cmd.Command(
+				"add-validation",
+				"Associate a validation with a validation plan",
+				addValidationToPlan,
+			)
+			cmd.Command(
+				"remove-validation",
+				"Remove an associated validation from a validation plan",
+				removeValidationFromPlan,
+			)
+		},
+	)
+}

--- a/pkg/commands/internal/validation/init.go
+++ b/pkg/commands/internal/validation/init.go
@@ -13,6 +13,7 @@ import (
 	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
+var validationUUID uuid.UUID
 var validationPlanUUID uuid.UUID
 
 // Init loads up the commands dealing with validations and validation plans
@@ -21,6 +22,32 @@ func Init(app *cli.Cli) {
 		"validations vs",
 		"List available validations",
 		getValidations,
+	)
+	app.Command(
+		"validation v",
+		"Commands for operating on a validation",
+		func(cmd *cli.Cmd) {
+
+			var validationPlanID = cmd.StringArg("ID", "", "The UUID of the validation plan")
+
+			cmd.Spec = "ID"
+
+			cmd.Before = func() {
+				util.BuildAPIAndVerifyLogin()
+				var err error
+				validationUUID, err = uuid.FromString(*validationPlanID)
+				if err != nil {
+					util.Bail(err)
+				}
+				return
+			}
+
+			cmd.Command(
+				"test",
+				"Test a validation against a given device with input data from STDIN",
+				testValidation,
+			)
+		},
 	)
 	app.Command(
 		"validation-plans vps",
@@ -82,6 +109,12 @@ func Init(app *cli.Cli) {
 				"remove-validation",
 				"Remove an associated validation from a validation plan",
 				removeValidationFromPlan,
+			)
+
+			cmd.Command(
+				"test",
+				"Test a validation plan against a given device with input data from STDIN",
+				testValidationPlan,
 			)
 		},
 	)

--- a/pkg/commands/internal/validation/init.go
+++ b/pkg/commands/internal/validation/init.go
@@ -118,4 +118,25 @@ func Init(app *cli.Cli) {
 			)
 		},
 	)
+	app.Command(
+		"validation-states vss",
+		"Commands for validation states",
+		func(cmd *cli.Cmd) {
+
+			cmd.Before = func() {
+				util.BuildAPIAndVerifyLogin()
+			}
+
+			cmd.Command(
+				"device",
+				"Get validation states for a device",
+				getDeviceValidationStates,
+			)
+			cmd.Command(
+				"workspace",
+				"Get validation states for all devices in a workspace",
+				getWorkspaceValidationStates,
+			)
+		},
+	)
 }

--- a/pkg/commands/internal/validation/plan.go
+++ b/pkg/commands/internal/validation/plan.go
@@ -1,0 +1,169 @@
+// Copyright 2018 Joyent, Inc.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package validation contains commands for validation related commands
+package validation
+
+import (
+	"fmt"
+	"github.com/joyent/conch-shell/pkg/util"
+	conch "github.com/joyent/go-conch"
+	"gopkg.in/jawher/mow.cli.v1"
+	uuid "gopkg.in/satori/go.uuid.v1"
+)
+
+type validationPlans []conch.ValidationPlan
+
+func (vps validationPlans) renderTable() {
+	table := util.GetMarkdownTable()
+	table.SetHeader([]string{"Id", "Name", "Description"})
+
+	for _, vp := range vps {
+		table.Append([]string{vp.ID.String(), vp.Name, vp.Description})
+	}
+
+	table.Render()
+}
+
+func getValidationPlans(app *cli.Cmd) {
+	app.Before = util.BuildAPIAndVerifyLogin
+
+	app.Action = func() {
+		var validationPlans validationPlans
+		validationPlans, err := util.API.GetValidationPlans()
+		if err != nil {
+			util.Bail(err)
+		}
+
+		if util.JSON {
+			util.JSONOut(validationPlans)
+			return
+		}
+		validationPlans.renderTable()
+	}
+}
+
+func getValidationPlan(app *cli.Cmd) {
+	app.Action = func() {
+		validationPlan, err := util.API.GetValidationPlan(validationPlanUUID)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		if util.JSON {
+			util.JSONOut(validationPlan)
+			return
+		}
+		validationPlans := validationPlans{*validationPlan}
+		validationPlans.renderTable()
+	}
+}
+
+func showValidationPlanValidations(app *cli.Cmd) {
+
+	app.Action = func() {
+		var validations validations
+		validations, err := util.API.GetValidationPlanValidations(validationPlanUUID)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		if util.JSON {
+			util.JSONOut(validations)
+			return
+		}
+		validations.renderTable()
+	}
+}
+
+func addValidationToPlan(app *cli.Cmd) {
+	app.Spec = "VALIDATION_ID"
+
+	var validationStrID = app.StringArg("VALIDATION_ID", "", "The ID of the validation to associate with the plan")
+
+	app.Action = func() {
+		validationUUID, err := uuid.FromString(*validationStrID)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		err = util.API.AddValidationToPlan(validationPlanUUID, validationUUID)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		var validations validations
+		validations, err = util.API.GetValidationPlanValidations(validationPlanUUID)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		if util.JSON {
+			util.JSONOut(validations)
+			return
+		}
+		validations.renderTable()
+	}
+}
+
+func removeValidationFromPlan(app *cli.Cmd) {
+	app.Spec = "VALIDATION_ID"
+
+	var validationStrID = app.StringArg("VALIDATION_ID", "", "The ID of the validation to remove from the plan")
+
+	app.Action = func() {
+		validationUUID, err := uuid.FromString(*validationStrID)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		err = util.API.RemoveValidationFromPlan(validationPlanUUID, validationUUID)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		var validations validations
+		validations, err = util.API.GetValidationPlanValidations(validationPlanUUID)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		if util.JSON {
+			util.JSONOut(validations)
+			return
+		}
+		validations.renderTable()
+	}
+}
+
+func createValidationPlan(app *cli.Cmd) {
+	var (
+		nameArg        = app.StringOpt("name", "", "The name for the new validation plan")
+		descriptionArg = app.StringOpt("description", "", "The description of the validation plan")
+	)
+
+	app.Spec = "--name --description"
+
+	app.Action = func() {
+		validationPlan := conch.ValidationPlan{
+			Name:        *nameArg,
+			Description: *descriptionArg,
+		}
+
+		newPlan, err := util.API.CreateValidationPlan(validationPlan)
+
+		if err != nil {
+			util.Bail(err)
+		}
+
+		if util.JSON {
+			util.JSONOut(newPlan)
+		} else {
+			fmt.Printf("Validation Plan '%s' created with ID '%s'\n", newPlan.Name, newPlan.ID)
+		}
+
+	}
+}

--- a/pkg/commands/internal/validation/plan.go
+++ b/pkg/commands/internal/validation/plan.go
@@ -13,7 +13,6 @@ import (
 	"github.com/joyent/conch-shell/pkg/util"
 	conch "github.com/joyent/go-conch"
 	"gopkg.in/jawher/mow.cli.v1"
-	uuid "gopkg.in/satori/go.uuid.v1"
 	"os"
 )
 
@@ -87,7 +86,7 @@ func addValidationToPlan(app *cli.Cmd) {
 	var validationStrID = app.StringArg("VALIDATION_ID", "", "The ID of the validation to associate with the plan")
 
 	app.Action = func() {
-		validationUUID, err := uuid.FromString(*validationStrID)
+		validationUUID, err := util.MagicValidationID(*validationStrID)
 		if err != nil {
 			util.Bail(err)
 		}
@@ -117,7 +116,7 @@ func removeValidationFromPlan(app *cli.Cmd) {
 	var validationStrID = app.StringArg("VALIDATION_ID", "", "The ID of the validation to remove from the plan")
 
 	app.Action = func() {
-		validationUUID, err := uuid.FromString(*validationStrID)
+		validationUUID, err := util.MagicValidationID(*validationStrID)
 		if err != nil {
 			util.Bail(err)
 		}
@@ -178,7 +177,7 @@ func testValidationPlan(app *cli.Cmd) {
 	app.Action = func() {
 		body := bufio.NewReader(os.Stdin)
 		var validationResults validationResults
-		validationResults, err := util.API.TestDeviceValidationPlan(*deviceSerial, validationPlanUUID, body)
+		validationResults, err := util.API.RunDeviceValidationPlan(*deviceSerial, validationPlanUUID, body)
 		if err != nil {
 			util.Bail(err)
 		}

--- a/pkg/commands/internal/validation/plan.go
+++ b/pkg/commands/internal/validation/plan.go
@@ -8,11 +8,13 @@
 package validation
 
 import (
+	"bufio"
 	"fmt"
 	"github.com/joyent/conch-shell/pkg/util"
 	conch "github.com/joyent/go-conch"
 	"gopkg.in/jawher/mow.cli.v1"
 	uuid "gopkg.in/satori/go.uuid.v1"
+	"os"
 )
 
 type validationPlans []conch.ValidationPlan
@@ -165,5 +167,26 @@ func createValidationPlan(app *cli.Cmd) {
 			fmt.Printf("Validation Plan '%s' created with ID '%s'\n", newPlan.Name, newPlan.ID)
 		}
 
+	}
+}
+
+func testValidationPlan(app *cli.Cmd) {
+	var deviceSerial = app.StringArg("DEVICE_ID", "", "The Device ID (serial number) to test the validation plan against")
+
+	app.Spec = "DEVICE_ID"
+
+	app.Action = func() {
+		body := bufio.NewReader(os.Stdin)
+		var validationResults validationResults
+		validationResults, err := util.API.TestDeviceValidationPlan(*deviceSerial, validationPlanUUID, body)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		if util.JSON {
+			util.JSONOut(validationResults)
+			return
+		}
+		validationResults.renderTable()
 	}
 }

--- a/pkg/commands/internal/validation/state.go
+++ b/pkg/commands/internal/validation/state.go
@@ -1,0 +1,114 @@
+// Copyright 2018 Joyent, Inc.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package validation contains commands for validation related commands
+package validation
+
+import (
+	"github.com/joyent/conch-shell/pkg/util"
+	conch "github.com/joyent/go-conch"
+	"gopkg.in/jawher/mow.cli.v1"
+	uuid "gopkg.in/satori/go.uuid.v1"
+	"strconv"
+)
+
+type validationStates []conch.ValidationState
+
+func (vs validationStates) renderTable(validationPlans []conch.ValidationPlan) {
+	table := util.GetMarkdownTable()
+
+	planNameMap := make(map[uuid.UUID]string)
+	for _, vp := range validationPlans {
+		planNameMap[vp.ID] = vp.Name
+	}
+
+	table.SetHeader([]string{
+		"Device ID",
+		"Status",
+		"Completed",
+		"Validation Plan",
+		"Pass / Fail / Error",
+	})
+
+	for _, v := range vs {
+		fails := 0
+		passes := 0
+		errors := 0
+		for _, r := range v.Results {
+			if r.Status == "pass" {
+				passes++
+			}
+			if r.Status == "fail" {
+				fails++
+			}
+			if r.Status == "error" {
+				errors++
+			}
+		}
+		table.Append([]string{
+			v.DeviceID,
+			v.Status,
+			v.Completed.String(),
+			planNameMap[v.ValidationPlanID],
+			strconv.Itoa(passes) + " / " + strconv.Itoa(fails) + " / " + strconv.Itoa(errors),
+		})
+	}
+
+	table.Render()
+}
+
+func getDeviceValidationStates(app *cli.Cmd) {
+	var deviceSerial = app.StringArg("DEVICE_ID", "", "The Device ID (serial number)")
+
+	app.Spec = "DEVICE_ID"
+
+	app.Action = func() {
+		var validationStates validationStates
+		validationStates, err := util.API.DeviceValidationStates(*deviceSerial)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		if util.JSON {
+			util.JSONOut(validationStates)
+			return
+		}
+		validationPlans, err := util.API.GetValidationPlans()
+		if err != nil {
+			util.Bail(err)
+		}
+		validationStates.renderTable(validationPlans)
+	}
+}
+
+func getWorkspaceValidationStates(app *cli.Cmd) {
+	var workspaceStrID = app.StringArg("WORKSPACE_ID", "", "The Workspace UUID")
+
+	app.Spec = "WORKSPACE_ID"
+
+	app.Action = func() {
+		workspaceUUID, err := util.MagicWorkspaceID(*workspaceStrID)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		var validationStates validationStates
+		validationStates, err = util.API.WorkspaceValidationStates(workspaceUUID)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		if util.JSON {
+			util.JSONOut(validationStates)
+			return
+		}
+		validationPlans, err := util.API.GetValidationPlans()
+		if err != nil {
+			util.Bail(err)
+		}
+		validationStates.renderTable(validationPlans)
+	}
+}

--- a/pkg/commands/internal/validation/validation.go
+++ b/pkg/commands/internal/validation/validation.go
@@ -70,7 +70,8 @@ func testValidation(app *cli.Cmd) {
 	app.Action = func() {
 		body := bufio.NewReader(os.Stdin)
 		var validationResults validationResults
-		validationResults, err := util.API.TestDeviceValidation(*deviceSerial, validationUUID, body)
+		validationResults, err :=
+			util.API.RunDeviceValidation(*deviceSerial, validationUUID, body)
 		if err != nil {
 			util.Bail(err)
 		}

--- a/pkg/commands/internal/validation/validation.go
+++ b/pkg/commands/internal/validation/validation.go
@@ -1,0 +1,47 @@
+// Copyright 2018 Joyent, Inc.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package validation contains commands for validation related commands
+package validation
+
+import (
+	"github.com/joyent/conch-shell/pkg/util"
+	conch "github.com/joyent/go-conch"
+	"gopkg.in/jawher/mow.cli.v1"
+	"strconv"
+)
+
+type validations []conch.Validation
+
+func (vs validations) renderTable() {
+	table := util.GetMarkdownTable()
+
+	table.SetHeader([]string{"Id", "Name", "Version", "Description"})
+
+	for _, v := range vs {
+		table.Append([]string{v.ID.String(), v.Name, strconv.Itoa(v.Version), v.Description})
+	}
+
+	table.Render()
+}
+
+func getValidations(app *cli.Cmd) {
+	app.Before = util.BuildAPIAndVerifyLogin
+
+	app.Action = func() {
+		var validations validations
+		validations, err := util.API.GetValidations()
+		if err != nil {
+			util.Bail(err)
+		}
+
+		if util.JSON {
+			util.JSONOut(validations)
+			return
+		}
+		validations.renderTable()
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -332,6 +332,66 @@ func MagicProductID(wat string) (uuid.UUID, error) {
 
 }
 
+// MagicValidationID takes a string and tries to find a valid UUID. If the
+// string is a UUID, it doesn't get checked further. Otherwise, we use
+// FindShortUUID to see if the string matches an existing Validation ID
+func MagicValidationID(s string) (uuid.UUID, error) {
+	id, err := uuid.FromString(s)
+	if err == nil {
+		return id, err
+	}
+
+	vs, err := API.GetValidations()
+	if err != nil {
+		return id, err
+	}
+	ids := make([]uuid.UUID, len(vs))
+	for i, v := range vs {
+		ids[i] = v.ID
+	}
+	id, err = FindShortUUID(s, ids)
+
+	return id, err
+
+}
+
+// MagicValidationPlanID takes a string and tries to find a valid UUID. If the
+// string is a UUID, it doesn't get checked further. Otherwise, we use
+// FindShortUUID to see if the string matches an existing Validation Plan ID
+func MagicValidationPlanID(s string) (uuid.UUID, error) {
+	id, err := uuid.FromString(s)
+	if err == nil {
+		return id, err
+	}
+
+	vs, err := API.GetValidationPlans()
+	if err != nil {
+		return id, err
+	}
+	ids := make([]uuid.UUID, len(vs))
+	for i, v := range vs {
+		ids[i] = v.ID
+	}
+	id, err = FindShortUUID(s, ids)
+
+	return id, err
+
+}
+
+// FindShortUUID takes a string and tries to find a UUID in a list of UUIDs
+// that match by prefix (first 4 bytes)
+func FindShortUUID(s string, uuids []uuid.UUID) (uuid.UUID, error) {
+	re := regexp.MustCompile(fmt.Sprintf("^%s-", s))
+	for _, uuid := range uuids {
+		if re.MatchString(uuid.String()) {
+			return uuid, nil
+		}
+	}
+	var id uuid.UUID
+	return id, errors.New("Could not find short UUID " + s)
+
+}
+
 // GithubRelease represents a 'release' for a Github project
 type GithubRelease struct {
 	URL     string         `json:"html_url"`


### PR DESCRIPTION
Add the following commands

* `conch validations`: list validations
* `conch validation-plans get`: list validation plans
* `conch validation-plans create --name <name> --description <description>`: create new validation plan
* `conch validation-plan ID get`: get details about a specific validation plan
* `conch validation-plan ID validations`: list validations associated with the plan
* `conch validation-plan ID add-validation VALIDATION_ID`: associate a validation with the plan
* `conch validation-plan ID remove-validation VALIDATION_ID`: associate a validation with the plan
* `conch validation ID test DEVICE_ID`: test the validation with the given device
* `conch validation-plan ID test DEVICE_ID`: test the validation plan with the given device
* `conch validation-states device DEVICE_ID`: get all validation states for the device
* `conch validation-states workspace WORKSPACE_ID`: get all validations states for all devices in a workspace