### PR TITLE
BREAKING: bring in go-conch v2, which removed pgtime 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -72,12 +72,9 @@
 
 [[projects]]
   name = "github.com/joyent/go-conch"
-  packages = [
-    ".",
-    "pgtime"
-  ]
-  revision = "b68c47c893ea9d51203703570d253a0f0c80bfc5"
-  version = "v1.2.0"
+  packages = ["."]
+  revision = "8dc9833e09e780a6a5a6f2a16c076a32e415a895"
+  version = "v2.0.0"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"
@@ -170,6 +167,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b7f100b7b1d79aed3f31ab66c0e2a05e4fe7e74108c7a57e5449015b2670c1e4"
+  inputs-digest = "6ae91e032b961b377cb6fc69b2fd581d1d108090b32f28512ad01018a39b1a35"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -87,4 +87,4 @@
 
 [[constraint]]
   name = "github.com/joyent/go-conch"
-  version = "1.2.0"
+  version = "2.0.0"

--- a/pkg/commands/internal/workspaces/failure.go
+++ b/pkg/commands/internal/workspaces/failure.go
@@ -10,11 +10,11 @@ import (
 	"fmt"
 	"github.com/joyent/conch-shell/pkg/util"
 	conch "github.com/joyent/go-conch"
-	"github.com/joyent/go-conch/pgtime"
 	"gopkg.in/jawher/mow.cli.v1"
 	uuid "gopkg.in/satori/go.uuid.v1"
 	"regexp"
 	"sort"
+	"time"
 )
 
 func getFailures(app *cli.Cmd) {
@@ -28,18 +28,18 @@ func getFailures(app *cli.Cmd) {
 
 		type minimalReportDevice struct {
 			AssetTag          string                              `json:"asset_tag"`
-			Created           pgtime.PgTime                       `json:"created, int"`
-			Graduated         pgtime.PgTime                       `json:"graduated"`
+			Created           time.Time                           `json:"created"`
+			Graduated         time.Time                           `json:"graduated"`
 			HardwareProduct   uuid.UUID                           `json:"hardware_product"`
 			Health            string                              `json:"health"`
 			ID                string                              `json:"id"`
-			LastSeen          pgtime.PgTime                       `json:"last_seen, int"`
+			LastSeen          time.Time                           `json:"last_seen"`
 			Location          conch.DeviceLocation                `json:"location"`
 			Role              uuid.UUID                           `json:"role"`
 			State             string                              `json:"state"`
 			SystemUUID        uuid.UUID                           `json:"system_uuid"`
-			Updated           pgtime.PgTime                       `json:"updated, int"`
-			Validated         pgtime.PgTime                       `json:"validated, int"`
+			Updated           time.Time                           `json:"updated"`
+			Validated         time.Time                           `json:"validated"`
 			FailedValidations map[string][]conch.ValidationReport `json:"failed_validations"`
 		}
 

--- a/pkg/commands/internal/workspaces/workspaces.go
+++ b/pkg/commands/internal/workspaces/workspaces.go
@@ -11,11 +11,11 @@ import (
 	gotree "github.com/DiSiqueira/GoTree"
 	"github.com/joyent/conch-shell/pkg/util"
 	"github.com/joyent/go-conch"
-	"github.com/joyent/go-conch/pgtime"
 	"gopkg.in/jawher/mow.cli.v1"
 	uuid "gopkg.in/satori/go.uuid.v1"
 	"sort"
 	"strconv"
+	"time"
 )
 
 func getAll(app *cli.Cmd) {
@@ -322,14 +322,14 @@ func getRelays(app *cli.Cmd) {
 		}
 
 		type resultRow struct {
-			ID         string        `json:"id"`
-			Alias      string        `json:"asset_tag"`
-			Created    pgtime.PgTime `json:"created, int"`
-			IPAddr     string        `json:"ipaddr"`
-			SSHPort    int           `json:"ssh_port"`
-			Updated    pgtime.PgTime `json:"updated"`
-			Version    string        `json:"version"`
-			NumDevices int           `json:"num_devices"`
+			ID         string    `json:"id"`
+			Alias      string    `json:"asset_tag"`
+			Created    time.Time `json:"created"`
+			IPAddr     string    `json:"ipaddr"`
+			SSHPort    int       `json:"ssh_port"`
+			Updated    time.Time `json:"updated"`
+			Version    string    `json:"version"`
+			NumDevices int       `json:"num_devices"`
 		}
 
 		results := make([]resultRow, 0)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -16,13 +16,13 @@ import (
 	"github.com/dghubble/sling"
 	"github.com/joyent/conch-shell/pkg/config"
 	conch "github.com/joyent/go-conch"
-	"github.com/joyent/go-conch/pgtime"
 	"github.com/olekukonko/tablewriter"
 	cli "gopkg.in/jawher/mow.cli.v1"
 	uuid "gopkg.in/satori/go.uuid.v1"
 	"os"
 	"regexp"
 	"strings"
+	"time"
 )
 
 var (
@@ -52,22 +52,22 @@ var (
 // output
 const DateFormat = "2006-01-02 15:04:05 -0700 MST"
 
-// TimeStr ensures that all PgTimes are formatted using .Local() and DateFormat
-func TimeStr(t pgtime.PgTime) string {
+// TimeStr ensures that all Times are formatted using .Local() and DateFormat
+func TimeStr(t time.Time) string {
 	return t.Local().Format(DateFormat)
 }
 
 // MinimalDevice represents a limited subset of Device data, that which we are
 // going to present to the user
 type MinimalDevice struct {
-	ID       string        `json:"id"`
-	AssetTag string        `json:"asset_tag"`
-	Created  pgtime.PgTime `json:"created,int"`
-	LastSeen pgtime.PgTime `json:"last_seen,int"`
-	Health   string        `json:"health"`
-	Flags    string        `json:"flags"`
-	AZ       string        `json:"az"`
-	Rack     string        `json:"rack"`
+	ID       string    `json:"id"`
+	AssetTag string    `json:"asset_tag"`
+	Created  time.Time `json:"created"`
+	LastSeen time.Time `json:"last_seen"`
+	Health   string    `json:"health"`
+	Flags    string    `json:"flags"`
+	AZ       string    `json:"az"`
+	Rack     string    `json:"rack"`
 }
 
 // BuildAPIAndVerifyLogin builds a Conch object using the Config data and calls


### PR DESCRIPTION
BREAKING: this alters the JSON output such that time values are now
RFC3339 strings and NOT epoch integers