### PR TITLE
feat: add command to render device report

### DIFF
--- a/pkg/commands/internal/devices/devices.go
+++ b/pkg/commands/internal/devices/devices.go
@@ -7,6 +7,8 @@
 package devices
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/joyent/conch-shell/pkg/util"
 	"github.com/joyent/go-conch"
@@ -303,5 +305,23 @@ func getAssetTag(app *cli.Cmd) {
 			util.Bail(err)
 		}
 		fmt.Println(d.AssetTag)
+	}
+}
+
+func getReport(app *cli.Cmd) {
+	app.Action = func() {
+		util.JSON = true
+		d, err := util.API.GetDevice(DeviceSerial)
+		if err != nil {
+			util.Bail(err)
+		}
+		if d.LatestReport.SerialNumber == "" {
+			util.Bail(errors.New("Device has not yet reported"))
+		}
+		j, err := json.MarshalIndent(d.LatestReport, "", "  ")
+		if err != nil {
+			util.Bail(err)
+		}
+		fmt.Println(string(j))
 	}
 }

--- a/pkg/commands/internal/devices/init.go
+++ b/pkg/commands/internal/devices/init.go
@@ -228,6 +228,12 @@ func Init(app *cli.Cli) {
 			)
 
 			cmd.Command(
+				"report",
+				"Get the latest recorded device report as JSON",
+				getReport,
+			)
+
+			cmd.Command(
 				"triton",
 				"Subcommands that deal with various Triton related settings",
 				func(cmd *cli.Cmd) {


### PR DESCRIPTION
`conch device ID report` renders the device's latest device report if present.

I ordered the device sub-command so they are in alphabetical order in the help screen.