### PR TITLE
docs: document in the README that one can override where go looks for SSL certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@
 Releases are available over at https://github.com/joyent/conch-shell/releases
 for a handful of platforms, including macOS, Linux, and Solaris/SmartOS.
 
+# Notes
+
+## SSL Certs
+
+Go makes a lot of assumptions about a user's runtime environment. One assumption
+is that a system holds SSL certs in a set of default directories which are
+hardcoded into the go runtime by platform. If the user's runtime differs from
+go's expectation, the user will receive a message like `x509: failed to load
+system roots and no roots provided`.
+
+To set a custom location for SSL certs, one can specify `SSL_CERT_DIR` or
+`SSL_CERT_FILE` in the environment before running conch shell.
+
+For instance: `SSL_CERT_FILE=/opt/certs.pem conch login`
+
+
 # Copyright / License
 
 Copyright Joyent Inc


### PR DESCRIPTION
Fixes #56 