### PR TITLE
Add support for device tagging

### DIFF
--- a/pkg/commands/internal/devices/init.go
+++ b/pkg/commands/internal/devices/init.go
@@ -25,8 +25,11 @@ var DeviceServiceUUID uuid.UUID
 // relevant command tree
 var DeviceRoleUUID uuid.UUID
 
-// DeviceSettingName is the name of the device setting being active upon
+// DeviceSettingName is the name of the device setting being acted upon
 var DeviceSettingName string
+
+// DeviceTagName is the name of the device tag being acted upon
+var DeviceTagName string
 
 // Init loads up all the device related commands
 func Init(app *cli.Cli) {
@@ -286,6 +289,48 @@ func Init(app *cli.Cli) {
 						"setup",
 						"Mark the device as having been setup in Triton. WARNING: This is a one-way operation that cannot be undone",
 						markTritonSetup,
+					)
+				},
+			)
+
+			// TAGS
+			cmd.Command(
+				"tags",
+				"Get the tags for a single device",
+				getTags,
+			)
+
+			cmd.Command(
+				"tag",
+				"Get the value of a single tag for a single device",
+				func(cmd *cli.Cmd) {
+					var tagNameArg = cmd.StringArg(
+						"NAME",
+						"",
+						"The name of the tag",
+					)
+					cmd.Spec = "NAME"
+
+					cmd.Before = func() {
+						DeviceTagName = *tagNameArg
+					}
+
+					cmd.Command(
+						"get",
+						"Get a particular device tag",
+						getTag,
+					)
+
+					cmd.Command(
+						"set",
+						"Set a particular device tag",
+						setTag,
+					)
+
+					cmd.Command(
+						"delete rm",
+						"Delete a particular device tag",
+						deleteTag,
 					)
 				},
 			)

--- a/pkg/conch/device_settings.go
+++ b/pkg/conch/device_settings.go
@@ -8,6 +8,7 @@ package conch
 
 import (
 	"regexp"
+	"strings"
 )
 
 // GetDeviceSettings fetches settings for a device, via
@@ -98,6 +99,101 @@ func (c *Conch) DeleteDeviceSetting(deviceID string, key string) error {
 	re := regexp.MustCompile("^tag\\.")
 	if re.MatchString(key) {
 		return ErrDataNotFound
+	}
+
+	aerr := &APIError{}
+	res, err := c.sling().New().Delete("/device/"+deviceID+"/settings/"+key).
+		Receive(nil, aerr)
+
+	return c.isHTTPResOk(res, err, aerr)
+}
+
+// GetDeviceTags fetches tags for a device, via /device/:serial/settings
+// Device settings that do NOT begin with 'tag.' are filtered out.
+func (c *Conch) GetDeviceTags(serial string) (map[string]string, error) {
+	settings := make(map[string]string)
+
+	aerr := &APIError{}
+
+	res, err := c.sling().New().
+		Get("/device/"+serial+"/settings").
+		Receive(&settings, aerr)
+
+	filtered := make(map[string]string)
+
+	if ret := c.isHTTPResOk(res, err, aerr); ret != nil {
+		return filtered, ret
+	}
+
+	// Settings that start with 'tag.' are special cased and only availabe
+	// in the device tag commands
+	re := regexp.MustCompile("^tag\\.")
+	for k, v := range settings {
+		if re.MatchString(k) {
+			filtered[strings.TrimPrefix(k, "tag.")] = v
+		}
+	}
+
+	return filtered, nil
+}
+
+//////////////////
+
+// GetDeviceTag fetches a single tag for a device, via
+// /device/:serial/settings/:key
+// The key must either begin with 'tag.' or it will be prepended
+func (c *Conch) GetDeviceTag(serial string, key string) (string, error) {
+
+	re := regexp.MustCompile("^tag\\.")
+	if !re.MatchString(key) {
+		key = "tag." + key
+	}
+
+	var setting string
+	j := make(map[string]string)
+
+	aerr := &APIError{}
+	res, err := c.sling().New().
+		Get("/device/"+serial+"/settings/"+key).
+		Receive(&j, aerr)
+
+	if _, ok := j[key]; ok {
+		setting = j[key]
+	}
+
+	return setting, c.isHTTPResOk(res, err, aerr)
+}
+
+// SetDeviceTag sets a single tag for a device via /device/:deviceID/settings/:key
+// The key must either begin with 'tag.' or it will be prepended
+func (c *Conch) SetDeviceTag(deviceID string, key string, value string) error {
+	// Settings that start with 'tag.' are special cased and only available
+	// in the device tag interface
+	re := regexp.MustCompile("^tag\\.")
+	if !re.MatchString(key) {
+		key = "tag." + key
+	}
+
+	j := make(map[string]string)
+	j[key] = value
+
+	aerr := &APIError{}
+	res, err := c.sling().New().Post("/device/"+deviceID+"/settings/"+key).
+		BodyJSON(j).Receive(nil, aerr)
+
+	return c.isHTTPResOk(res, err, aerr)
+}
+
+// DeleteDeviceTag deletes a single tag for a device via
+// /device/:deviceID/settings/:key
+// Settings that do NOT begin with "tag." cannot be processed by this routine
+// and will always return ErrDataNotFound
+func (c *Conch) DeleteDeviceTag(deviceID string, key string) error {
+	// Settings that start with 'tag.' are special cased and only available
+	// in the device tag interface
+	re := regexp.MustCompile("^tag\\.")
+	if !re.MatchString(key) {
+		key = "tag." + key
 	}
 
 	aerr := &APIError{}

--- a/pkg/conch/device_settings_test.go
+++ b/pkg/conch/device_settings_test.go
@@ -67,4 +67,50 @@ func TestDeviceSettingsErrors(t *testing.T) {
 		st.Expect(t, err, aerrUnpacked)
 	})
 
+	t.Run("GetDeviceTags", func(t *testing.T) {
+		serial := "test"
+
+		gock.New(API.BaseURL).Get("/device/" + serial + "/settings").
+			Reply(400).JSON(aerr)
+
+		ret, err := API.GetDeviceTags(serial)
+		st.Expect(t, err, aerrUnpacked)
+		st.Expect(t, ret, make(map[string]string))
+	})
+
+	t.Run("GetDeviceTag", func(t *testing.T) {
+		serial := "test"
+		key := "key"
+
+		gock.New(API.BaseURL).Get("/device/" + serial + "/settings/tag." + key).
+			Reply(400).JSON(aerr)
+
+		ret, err := API.GetDeviceTag(serial, key)
+		st.Expect(t, err, aerrUnpacked)
+		var setting string
+		st.Expect(t, ret, setting)
+	})
+
+	t.Run("SetDeviceTag", func(t *testing.T) {
+		serial := "test"
+		key := "key"
+
+		gock.New(API.BaseURL).Post("/device/" + serial + "/settings/tag." + key).
+			Reply(400).JSON(aerr)
+
+		err := API.SetDeviceTag(serial, key, "val")
+		st.Expect(t, err, aerrUnpacked)
+	})
+
+	t.Run("DeleteDeviceTag", func(t *testing.T) {
+		serial := "test"
+		key := "key"
+
+		gock.New(API.BaseURL).Delete("/device/" + serial + "/settings/tag." + key).
+			Reply(400).JSON(aerr)
+
+		err := API.DeleteDeviceTag(serial, key)
+		st.Expect(t, err, aerrUnpacked)
+	})
+
 }


### PR DESCRIPTION
Per https://github.com/joyent/conch/issues/357 we want the ability to CRUD tags for devices. What this looks like is special-casing a prefix in device settings. "Tags" simply start with `tag.` and are otherwise treated like device settings. This is partially for historical reasons -- "settings" are used during the build process, and we don't want to cause confusion between run-time "tagging" and build-time metadata.

A new `tag` subcommand (which behaves the same as `settings`) should be added.