### PR TITLE
Crash with version sub-command

### DIFF
--- a/cmd/conch/conch.go
+++ b/cmd/conch/conch.go
@@ -82,8 +82,10 @@ func main() {
 		if *noVersion {
 			checkVersion = false
 		}
-		if util.ActiveProfile.SkipVersionCheck {
-			checkVersion = false
+		if util.ActiveProfile != nil {
+			if util.ActiveProfile.SkipVersionCheck {
+				checkVersion = false
+			}
 		}
 
 		if checkVersion {


### PR DESCRIPTION
Low-priority bug/observation using shell version 1.4.0

On Debian 9 x86 is the following crash when issuing `conch version`:
```
daleg-drd:~# conch version
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x80 pc=0x73cfb2]

goroutine 1 [running]:
github.com/joyent/conch-shell/vendor/github.com/jawher/mow.cli/internal/flow.(*Step).Run(0xc420063950, 0x7a0ba0, 0xa2bf60)
	/usr/home/buildbot/bb/master/workers/go-worker/conch-shell-release/src/github.com/joyent/conch-shell/vendor/github.com/jawher/mow.cli/internal/flow/flow.go:39 +0xda
github.com/joyent/conch-shell/vendor/github.com/jawher/mow.cli/internal/flow.(*Step).callDo.func1(0xc420063980, 0x0, 0x0)
	/usr/home/buildbot/bb/master/workers/go-worker/conch-shell-release/src/github.com/joyent/conch-shell/vendor/github.com/jawher/mow.cli/internal/flow/flow.go:52 +0x4c
panic(0x7a0ba0, 0xa2bf60)
	/usr/local/go/src/runtime/panic.go:502 +0x229
main.main.func2()
	/usr/home/buildbot/bb/master/workers/go-worker/conch-shell-release/src/github.com/joyent/conch-shell/cmd/conch/conch.go:85 +0x172
github.com/joyent/conch-shell/vendor/github.com/jawher/mow.cli/internal/flow.(*Step).callDo(0xc420063980, 0x0, 0x0)
	/usr/home/buildbot/bb/master/workers/go-worker/conch-shell-release/src/github.com/joyent/conch-shell/vendor/github.com/jawher/mow.cli/internal/flow/flow.go:55 +0x70
github.com/joyent/conch-shell/vendor/github.com/jawher/mow.cli/internal/flow.(*Step).Run(0xc420063980, 0x0, 0x0)
	/usr/home/buildbot/bb/master/workers/go-worker/conch-shell-release/src/github.com/joyent/conch-shell/vendor/github.com/jawher/mow.cli/internal/flow/flow.go:25 +0x43
github.com/joyent/conch-shell/vendor/github.com/jawher/mow.cli/internal/flow.(*Step).Run(0xc420115ea8, 0x0, 0x0)
	/usr/home/buildbot/bb/master/workers/go-worker/conch-shell-release/src/github.com/joyent/conch-shell/vendor/github.com/jawher/mow.cli/internal/flow/flow.go:29 +0xc2
github.com/joyent/conch-shell/vendor/github.com/jawher/mow%2ecli.(*Cmd).parse(0xc4200fa500, 0xc42000a070, 0x0, 0x0, 0xc420115ea8, 0xc420063980, 0xc4200639b0, 0x428764, 0x828180)
	/usr/home/buildbot/bb/master/workers/go-worker/conch-shell-release/src/github.com/joyent/conch-shell/vendor/github.com/jawher/mow.cli/commands.go:496 +0x517
github.com/joyent/conch-shell/vendor/github.com/jawher/mow%2ecli.(*Cmd).parse(0xc4200fa400, 0xc42000a070, 0x1, 0x1, 0xc420115ea8, 0xc420043ea8, 0xc420063950, 0x1, 0xc420063950)
	/usr/home/buildbot/bb/master/workers/go-worker/conch-shell-release/src/github.com/joyent/conch-shell/vendor/github.com/jawher/mow.cli/commands.go:510 +0x72e
github.com/joyent/conch-shell/vendor/github.com/jawher/mow%2ecli.(*Cli).parse(0xc420043f48, 0xc42000a070, 0x1, 0x1, 0xc420043ea8, 0xc420043ea8, 0xc420063950, 0x80cc64, 0x6)
	/usr/home/buildbot/bb/master/workers/go-worker/conch-shell-release/src/github.com/joyent/conch-shell/vendor/github.com/jawher/mow.cli/cli.go:76 +0xf5
github.com/joyent/conch-shell/vendor/github.com/jawher/mow%2ecli.(*Cli).Run(0xc420043f48, 0xc42000a060, 0x2, 0x2, 0x8140e7, 0x19)
	/usr/home/buildbot/bb/master/workers/go-worker/conch-shell-release/src/github.com/joyent/conch-shell/vendor/github.com/jawher/mow.cli/cli.go:105 +0x142
main.main()
	/usr/home/buildbot/bb/master/workers/go-worker/conch-shell-release/src/github.com/joyent/conch-shell/cmd/conch/conch.go:112 +0x3de
```

However, on the same platform, `conch --version` works:
```
daleg-drd:~# conch --version
1.4.0
```

On macOS X, `conch version` successfully runs:
```
[daleg@iridium]~$ conch version
Conch Shell v1.4.0
  Git Revision: v1.4.0-0-g7c0de73
  Build Time: 2018-08-29 16:19:20 -0400 EDT
  Build Host: buildbot@conch-buildbot
```


