### PR TITLE
when loading the config file from json with or without a path, always use New() so we get sane defaults

### DIFF
--- a/cmd/conch/conch.go
+++ b/cmd/conch/conch.go
@@ -67,10 +67,8 @@ func main() {
 			util.Bail(err)
 		}
 
-		cfg, err := config.NewFromJSONFile(expandedPath)
-		if err == nil {
-			cfg.Path = expandedPath
-		}
+		cfg, _ := config.NewFromJSONFile(expandedPath)
+		cfg.Path = expandedPath
 		util.Config = cfg
 
 		for _, prof := range cfg.Profiles {

--- a/pkg/config/main.go
+++ b/pkg/config/main.go
@@ -53,10 +53,9 @@ func New() (c *ConchConfig) {
 	return c
 }
 
-// NewFromJSON unmarshals a JSON blob into a ConchConfig struct. It does
-// *not* fill in any default values.
+// NewFromJSON unmarshals a JSON blob into a ConchConfig struct
 func NewFromJSON(j string) (c *ConchConfig, err error) {
-	c = &ConchConfig{}
+	c = New()
 
 	err = json.Unmarshal([]byte(j), c)
 	if err != nil {
@@ -71,13 +70,12 @@ func NewFromJSON(j string) (c *ConchConfig, err error) {
 }
 
 // NewFromJSONFile reads a file off disk and unmarshals it into ConchConfig
-// struct. It does *not* fill in any default values
+// struct.
 func NewFromJSONFile(path string) (c *ConchConfig, err error) {
-	c = &ConchConfig{Profiles: make(map[string]*ConchProfile)}
 
 	raw, err := ioutil.ReadFile(path)
 	if err != nil {
-		return c, err
+		return New(), err
 	}
 
 	return NewFromJSON(string(raw))


### PR DESCRIPTION
This fixes an error reported by @rjloura in MM