### PR TITLE
stop displaying the nonsensical UNIT field when showing workspace racks and drop a BUG about the strange field

### DIFF
--- a/pkg/commands/internal/workspaces/workspaces.go
+++ b/pkg/commands/internal/workspaces/workspaces.go
@@ -208,7 +208,6 @@ func getRacks(app *cli.Cmd) {
 			"ID",
 			"Name",
 			"Role",
-			"Unit",
 			"Size",
 		})
 
@@ -217,7 +216,6 @@ func getRacks(app *cli.Cmd) {
 				r.ID.String(),
 				r.Name,
 				r.Role,
-				strconv.Itoa(r.Unit),
 				strconv.Itoa(r.Size),
 			})
 		}

--- a/pkg/conch/devices.go
+++ b/pkg/conch/devices.go
@@ -133,7 +133,7 @@ type Rack struct {
 	ID         uuid.UUID `json:"id"`
 	Name       string    `json:"name"`
 	Role       string    `json:"role"`
-	Unit       int       `json:"unit"`
+	Unit       int       `json:"unit"` // BUG(sungo): This exists because device locations provide rack info, but also slot info. This is a sloppy combination of data streams
 	Size       int       `json:"size"`
 	Datacenter string    `json:"datacenter"`
 	// The key of the Slots map is the RU slot number


### PR DESCRIPTION
In response to https://github.com/joyent/conch-shell/issues/62#issuecomment-419544578