### PR TITLE
when rendering a Rack as JSON, if the Slots element is null, do not render it

### DIFF
--- a/pkg/conch/devices.go
+++ b/pkg/conch/devices.go
@@ -127,14 +127,13 @@ type HardwareProductTarget struct {
 
 // Rack represents a physical rack
 type Rack struct {
-	ID         uuid.UUID `json:"id"`
-	Name       string    `json:"name"`
-	Role       string    `json:"role"`
-	Unit       int       `json:"unit"` // BUG(sungo): This exists because device locations provide rack info, but also slot info. This is a sloppy combination of data streams
-	Size       int       `json:"size"`
-	Datacenter string    `json:"datacenter"`
-	// The key of the Slots map is the RU slot number
-	Slots        []RackSlot `json:"slots"`
+	ID           uuid.UUID  `json:"id"`
+	Name         string     `json:"name"`
+	Role         string     `json:"role"`
+	Unit         int        `json:"unit"` // BUG(sungo): This exists because device locations provide rack info, but also slot info. This is a sloppy combination of data streams
+	Size         int        `json:"size"`
+	Datacenter   string     `json:"datacenter"`
+	Slots        []RackSlot `json:"slots,omitempty"`
 	SerialNumber string     `json:"serial_number"`
 	AssetTag     string     `json:"asset_tag"`
 }


### PR DESCRIPTION
This resolves some confusion when displaying a list of racks in a workspace. Previously, the `slots` element was present but marked as null.