### PR TITLE
For our standards checking, switch from gometalinter to staticcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ ARG CACHE_BUSTER="wat"
 
 ENV PATH "/go/bin:${PATH}"
 
-RUN go get github.com/alecthomas/gometalinter && \
-	gometalinter --install
+RUN go get honnef.co/go/tools/cmd/staticcheck
 
 RUN mkdir -p /go/src/github.com/joyent/conch-shell/
 WORKDIR /go/src/github.com/joyent/conch-shell/
@@ -20,7 +19,7 @@ LABEL org.label-schema.version $VERSION
 
 COPY . /go/src/github.com/joyent/conch-shell/
 
-RUN make default
+RUN make
 
 FROM scratch
 COPY --from=build /go/src/github.com/joyent/conch-shell/bin/conch /bin/conch

--- a/Makefile
+++ b/Makefile
@@ -55,35 +55,18 @@ checksums: ## Build checksums for all release binaries
 	@rm -f release/*.sha256
 	@cd release && find . -type f -iname conch-\* -print0 | xargs -0 -n 1 -I {} sh -c 'shasum -a 256 {} > "{}.sha256"'
 
-# gem install github_changelog_generator
-changelog:
-	github_changelog_generator -u joyent -p conch-shell #--due-tag ${CONCH_VERSION}
 
 .PHONY: check
 check: ## Ensure that code matchs best practices and run tests
 	@echo "==> Checking for best practices"
-	gometalinter \
-		--deadline 10m \
-		--vendor \
-		--sort="path" \
-		--aggregate \
-		--enable-gc \
-		--disable-all \
-		--enable vet \
-		--enable deadcode \
-		--enable varcheck \
-		--enable ineffassign \
-		--enable golint \
-		--enable gofmt \
-		./...
+	staticcheck ./...
 	@echo "==> Tests for pkg/conch"
 	@cd pkg/conch && go test -v 
 
 tools: ## Download and install all dev/code tools
 	@echo "==> Installing dev tools"
 	go get -u github.com/golang/dep/cmd/dep
-	go get -u github.com/alecthomas/gometalinter
-	gometalinter --install
+	go get -u honnef.co/go/tools/cmd/staticcheck
 
 
 .PHONY: help

--- a/cmd/conch/conch.go
+++ b/cmd/conch/conch.go
@@ -86,7 +86,7 @@ func main() {
 			}
 		}
 		if (*profileOverride != "") && (util.ActiveProfile == nil) {
-			util.Bail(fmt.Errorf("Could not find a profile named '%s'", *profileOverride))
+			util.Bail(fmt.Errorf("could not find a profile named '%s'", *profileOverride))
 		}
 
 		checkVersion := true

--- a/pkg/commands/internal/api/main.go
+++ b/pkg/commands/internal/api/main.go
@@ -27,7 +27,7 @@ func get(cmd *cli.Cmd) {
 				util.Bail(err)
 			}
 			if res == nil {
-				util.Bail(errors.New("Empty response"))
+				util.Bail(errors.New("empty response"))
 			}
 
 			body, err := ioutil.ReadAll(res.Body)
@@ -60,7 +60,7 @@ func deleteAPI(cmd *cli.Cmd) {
 				util.Bail(err)
 			}
 			if res == nil {
-				util.Bail(errors.New("Empty response"))
+				util.Bail(errors.New("empty response"))
 			}
 
 			body, err := ioutil.ReadAll(res.Body)
@@ -107,7 +107,7 @@ func postAPI(cmd *cli.Cmd) {
 			util.Bail(err)
 		}
 		if res == nil {
-			util.Bail(errors.New("Empty response"))
+			util.Bail(errors.New("empty response"))
 		}
 
 		body, err := ioutil.ReadAll(res.Body)

--- a/pkg/commands/internal/global/rack.go
+++ b/pkg/commands/internal/global/rack.go
@@ -338,7 +338,7 @@ func rackImportLayout(cmd *cli.Cmd) {
 
 		if len(existingLayout) > 0 {
 			if *overwriteOpt == false {
-				util.Bail(errors.New("Rack already has a layout. Use --overwrite to overwrite"))
+				util.Bail(errors.New("rack already has a layout. Use --overwrite to overwrite"))
 			}
 		}
 

--- a/pkg/commands/internal/global/rack.go
+++ b/pkg/commands/internal/global/rack.go
@@ -337,7 +337,7 @@ func rackImportLayout(cmd *cli.Cmd) {
 		}
 
 		if len(existingLayout) > 0 {
-			if *overwriteOpt == false {
+			if !*overwriteOpt {
 				util.Bail(errors.New("rack already has a layout. Use --overwrite to overwrite"))
 			}
 		}
@@ -405,7 +405,7 @@ func rackImportLayout(cmd *cli.Cmd) {
 
 		// If the rack has a layout, and the user asked us to, nuke the
 		// existing layout
-		if *overwriteOpt == true {
+		if *overwriteOpt {
 			for _, s := range existingLayout {
 				err := util.API.DeleteGlobalRackLayoutSlot(s.ID)
 				if err != nil {

--- a/pkg/commands/internal/hardware/hardware.go
+++ b/pkg/commands/internal/hardware/hardware.go
@@ -229,7 +229,7 @@ func createOne(app *cli.Cmd) {
 				util.Bail(err)
 			}
 			if len(string(b)) <= 1 {
-				util.Bail(errors.New("No specification provided"))
+				util.Bail(errors.New("no specification provided"))
 			}
 			h.Specification = string(b)
 		}
@@ -325,7 +325,7 @@ func updateOne(app *cli.Cmd) {
 				util.Bail(err)
 			}
 			if len(string(b)) <= 1 {
-				util.Bail(errors.New("No specification provided"))
+				util.Bail(errors.New("no specification provided"))
 			}
 			h.Specification = string(b)
 		}

--- a/pkg/commands/internal/hardware/init.go
+++ b/pkg/commands/internal/hardware/init.go
@@ -63,7 +63,7 @@ func Init(app *cli.Cli) {
 					cmd.Before = func() {
 						ProductUUID, _ = util.MagicProductID(*productIDStr)
 						if uuid.Equal(ProductUUID, uuid.UUID{}) {
-							util.Bail(errors.New("Could not resolve the hardware product ID, name, or SKU"))
+							util.Bail(errors.New("could not resolve the hardware product ID, name, or SKU"))
 						}
 					}
 

--- a/pkg/commands/internal/profile/profile.go
+++ b/pkg/commands/internal/profile/profile.go
@@ -49,7 +49,7 @@ func newProfile(app *cli.Cmd) {
 			if _, ok := util.Config.Profiles[p.Name]; ok {
 				util.Bail(
 					fmt.Errorf(
-						"A profile already exists with name '%s'",
+						"a profile already exists with name '%s'",
 						p.Name,
 					),
 				)
@@ -272,7 +272,7 @@ func setActive(app *cli.Cmd) {
 			}
 		} else {
 			util.Bail(
-				fmt.Errorf("Profile '%s' does not exist", *profileArg),
+				fmt.Errorf("profile '%s' does not exist", *profileArg),
 			)
 		}
 
@@ -288,7 +288,7 @@ func refreshJWT(app *cli.Cmd) {
 	app.Action = func() {
 		util.BuildAPI()
 		if util.ActiveProfile == nil {
-			util.Bail(errors.New("No active profile. Please use 'conch profile' to create or set an active profile"))
+			util.Bail(errors.New("no active profile. Please use 'conch profile' to create or set an active profile"))
 		}
 
 		if err := util.API.VerifyLogin(0, true); err != nil {

--- a/pkg/commands/internal/validation/init.go
+++ b/pkg/commands/internal/validation/init.go
@@ -39,7 +39,6 @@ func Init(app *cli.Cli) {
 				if err != nil {
 					util.Bail(err)
 				}
-				return
 			}
 
 			cmd.Command(
@@ -85,7 +84,6 @@ func Init(app *cli.Cli) {
 
 					util.Bail(err)
 				}
-				return
 			}
 
 			cmd.Command(

--- a/pkg/commands/internal/workspaces/init.go
+++ b/pkg/commands/internal/workspaces/init.go
@@ -60,7 +60,6 @@ func Init(app *cli.Cli) {
 					util.Bail(errors.New("no workspace was found in the active profile"))
 				}
 				WorkspaceUUID = util.ActiveProfile.WorkspaceUUID
-				return
 			}
 
 			cmd.Command(

--- a/pkg/commands/internal/workspaces/init.go
+++ b/pkg/commands/internal/workspaces/init.go
@@ -51,13 +51,13 @@ func Init(app *cli.Cli) {
 				if len(*workspaceIDStr) > 0 {
 					newUUID, _ = util.MagicWorkspaceID(*workspaceIDStr)
 					if uuid.Equal(newUUID, uuid.UUID{}) {
-						util.Bail(fmt.Errorf("Workspace %s does not exist or you do not have permission to access it", *workspaceIDStr))
+						util.Bail(fmt.Errorf("workspace %s does not exist or you do not have permission to access it", *workspaceIDStr))
 					}
 					WorkspaceUUID = newUUID
 					return
 				}
 				if uuid.Equal(util.ActiveProfile.WorkspaceUUID, uuid.UUID{}) {
-					util.Bail(errors.New("No workspace was found in the active profile"))
+					util.Bail(errors.New("no workspace was found in the active profile"))
 				}
 				WorkspaceUUID = util.ActiveProfile.WorkspaceUUID
 				return

--- a/pkg/commands/internal/workspaces/user.go
+++ b/pkg/commands/internal/workspaces/user.go
@@ -96,7 +96,7 @@ func removeUser(app *cli.Cmd) {
 						if err != nil {
 							util.Bail(err)
 						}
-						util.Bail(fmt.Errorf("Cannot continue. User %s has access to this workspace via the parent workspace %s", *emailArg, ws.Name))
+						util.Bail(fmt.Errorf("cannot continue. User %s has access to this workspace via the parent workspace %s", *emailArg, ws.Name))
 						return
 					}
 				}

--- a/pkg/conch/device_settings.go
+++ b/pkg/conch/device_settings.go
@@ -11,6 +11,12 @@ import (
 	"strings"
 )
 
+func isTag(str string) bool {
+	// Settings that start with 'tag.' are special cased and only available
+	// in the device tag commands
+	return regexp.MustCompile(`^tag\.`).MatchString(str)
+}
+
 // GetDeviceSettings fetches settings for a device, via
 // /device/:serial/settings
 // Device settings that begin with 'tag.' are filtered out.
@@ -29,11 +35,8 @@ func (c *Conch) GetDeviceSettings(serial string) (map[string]string, error) {
 		return filtered, ret
 	}
 
-	// Settings that start with 'tag.' are special cased and only available
-	// in the device tag commands
-	re := regexp.MustCompile("^tag\\.")
 	for k, v := range settings {
-		if !re.MatchString(k) {
+		if !isTag(k) {
 			filtered[k] = v
 		}
 	}
@@ -46,10 +49,7 @@ func (c *Conch) GetDeviceSettings(serial string) (map[string]string, error) {
 // Device settings that begin with 'tag.' are filtered out.
 func (c *Conch) GetDeviceSetting(serial string, key string) (string, error) {
 
-	// Settings that start with 'tag.' are special cased and only available
-	// in the device tag interface
-	re := regexp.MustCompile("^tag\\.")
-	if re.MatchString(key) {
+	if isTag(key) {
 		return "", ErrDataNotFound
 	}
 
@@ -72,10 +72,7 @@ func (c *Conch) GetDeviceSetting(serial string, key string) (string, error) {
 // Settings that begin with "tag." cannot be processed by this routine and will
 // always return ErrDataNotFound
 func (c *Conch) SetDeviceSetting(deviceID string, key string, value string) error {
-	// Settings that start with 'tag.' are special cased and only available
-	// in the device tag interface
-	re := regexp.MustCompile("^tag\\.")
-	if re.MatchString(key) {
+	if isTag(key) {
 		return ErrDataNotFound
 	}
 
@@ -94,10 +91,7 @@ func (c *Conch) SetDeviceSetting(deviceID string, key string, value string) erro
 // Settings that begin with "tag." cannot be processed by this routine and will
 // always return ErrDataNotFound
 func (c *Conch) DeleteDeviceSetting(deviceID string, key string) error {
-	// Settings that start with 'tag.' are special cased and only available
-	// in the device tag interface
-	re := regexp.MustCompile("^tag\\.")
-	if re.MatchString(key) {
+	if isTag(key) {
 		return ErrDataNotFound
 	}
 
@@ -125,11 +119,8 @@ func (c *Conch) GetDeviceTags(serial string) (map[string]string, error) {
 		return filtered, ret
 	}
 
-	// Settings that start with 'tag.' are special cased and only available
-	// in the device tag commands
-	re := regexp.MustCompile("^tag\\.")
 	for k, v := range settings {
-		if re.MatchString(k) {
+		if isTag(k) {
 			filtered[strings.TrimPrefix(k, "tag.")] = v
 		}
 	}
@@ -144,8 +135,7 @@ func (c *Conch) GetDeviceTags(serial string) (map[string]string, error) {
 // The key must either begin with 'tag.' or it will be prepended
 func (c *Conch) GetDeviceTag(serial string, key string) (string, error) {
 
-	re := regexp.MustCompile("^tag\\.")
-	if !re.MatchString(key) {
+	if !isTag(key) {
 		key = "tag." + key
 	}
 
@@ -167,10 +157,7 @@ func (c *Conch) GetDeviceTag(serial string, key string) (string, error) {
 // SetDeviceTag sets a single tag for a device via /device/:deviceID/settings/:key
 // The key must either begin with 'tag.' or it will be prepended
 func (c *Conch) SetDeviceTag(deviceID string, key string, value string) error {
-	// Settings that start with 'tag.' are special cased and only available
-	// in the device tag interface
-	re := regexp.MustCompile("^tag\\.")
-	if !re.MatchString(key) {
+	if !isTag(key) {
 		key = "tag." + key
 	}
 
@@ -189,10 +176,7 @@ func (c *Conch) SetDeviceTag(deviceID string, key string, value string) error {
 // Settings that do NOT begin with "tag." cannot be processed by this routine
 // and will always return ErrDataNotFound
 func (c *Conch) DeleteDeviceTag(deviceID string, key string) error {
-	// Settings that start with 'tag.' are special cased and only available
-	// in the device tag interface
-	re := regexp.MustCompile("^tag\\.")
-	if !re.MatchString(key) {
+	if !isTag(key) {
 		key = "tag." + key
 	}
 

--- a/pkg/conch/errors.go
+++ b/pkg/conch/errors.go
@@ -24,16 +24,16 @@ func (ai *APIError) Error() error {
 var (
 	// ErrLoginFailed indicates that the login process failed for unspecified
 	// reasons
-	ErrLoginFailed = errors.New("Login Failed")
+	ErrLoginFailed = errors.New("login failed")
 
 	// ErrNoSessionData indicates that an auth related error occurred where
 	// either the user did not provide session data or no data was returned
 	// from the API
-	ErrNoSessionData = errors.New("No Session Data Provided")
+	ErrNoSessionData = errors.New("no session data provided")
 
 	// ErrHTTPNotOk indicates that the API returned a non-200 status code that
 	// we don't know how to handle
-	ErrHTTPNotOk = errors.New("Non-200 HTTP status code returned")
+	ErrHTTPNotOk = errors.New("non-200 HTTP status code returned")
 
 	// ErrDataNotFound inidicates that the API returned a status code
 	// inidicating that the requested data does not exist or is not available.
@@ -44,26 +44,26 @@ var (
 	// ErrBadInput indicates that the user passed incomplete or bad data to a
 	// routine. This typicallly only occurs when a struct parameter isn't
 	// filled out with enough data.
-	ErrBadInput = errors.New("Incomplete data passed to the routine")
+	ErrBadInput = errors.New("incomplete data passed to the routine")
 
 	// ErrSemVerParse indicates that a semantic version string could not be
 	// parsed
-	ErrSemVerParse = errors.New("Could not parse semantic version string")
+	ErrSemVerParse = errors.New("could not parse semantic version string")
 
 	// ErrNotSupported indicates that the API server does not support this
 	// command. This is typically determined via checks on conch.apiVersion
-	ErrNotSupported = errors.New("This function is not supported")
+	ErrNotSupported = errors.New("this function is not supported")
 
 	// ErrNotAuthorized indicates that the API server returned a 401
-	ErrNotAuthorized = errors.New("Not authorized for this endpoint")
+	ErrNotAuthorized = errors.New("not authorized for this endpoint")
 
 	// ErrForbidden indicates that the API server returned a 403
-	ErrForbidden = errors.New("Access to this endpoint is forbidden")
+	ErrForbidden = errors.New("access to this endpoint is forbidden")
 
 	// ErrMustChangePassword is used to signal that the user must change their
 	// password before proceeding. Typically, the existing auth credentials
 	// will continue to work for a few minutes.
-	ErrMustChangePassword = errors.New("Password must be changed")
+	ErrMustChangePassword = errors.New("password must be changed")
 )
 
 // isHTTPResOk is a convenience function to abstract out all the code to see

--- a/pkg/config/main.go
+++ b/pkg/config/main.go
@@ -17,7 +17,7 @@ import (
 
 // ErrConfigNoPath is issued when a file operation is attempted on a
 // ConchConfig that lacks a path
-var ErrConfigNoPath = errors.New("No path found in config data")
+var ErrConfigNoPath = errors.New("no path found in config data")
 
 // ConchConfig represents the configuration information for the shell, mostly
 // just a profile list

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -100,7 +100,7 @@ func WriteConfig() {
 // BuildAPI builds a Conch object
 func BuildAPI() {
 	if ActiveProfile == nil {
-		Bail(errors.New("No active profile. Please use 'conch profile' to create or set an active profile"))
+		Bail(errors.New("no active profile. Please use 'conch profile' to create or set an active profile"))
 	}
 
 	API = &conch.Conch{
@@ -332,11 +332,11 @@ func LatestGithubRelease(owner string, repo string) (*GithubRelease, error) {
 // and restrictions
 func IsPasswordSane(password string, profile *config.ConchProfile) error {
 	if utf8.RuneCountInString(password) < 12 {
-		return errors.New("Length must be >= 12")
+		return errors.New("length must be >= 12")
 	}
 	if profile != nil {
 		if strings.EqualFold(password, profile.User) {
-			return errors.New("Password cannot match user name")
+			return errors.New("password cannot match user name")
 		}
 	}
 	return nil


### PR DESCRIPTION
Staticcheck is more deliberate about its work and, perhaps most importantly, provides the ability to skip checks either entirely or for a specific section of code.