### PR TITLE
Abstract the http calls into common routines

### DIFF
--- a/pkg/commands/init.go
+++ b/pkg/commands/init.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Joyent, Inc.
+// Copyright Joyent, Inc.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pkg/commands/internal/global/role.go
+++ b/pkg/commands/internal/global/role.go
@@ -139,7 +139,7 @@ func roleUpdate(app *cli.Cmd) {
 			r.RackSize = *rackSizeOpt
 		}
 
-		if err := util.API.SaveGlobalRackRole(r); err != nil {
+		if err := util.API.SaveGlobalRackRole(&r); err != nil {
 			util.Bail(err)
 		}
 

--- a/pkg/commands/internal/hardware/init.go
+++ b/pkg/commands/internal/hardware/init.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Joyent, Inc.
+// Copyright Joyent, Inc.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pkg/commands/internal/profile/init.go
+++ b/pkg/commands/internal/profile/init.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Joyent, Inc.
+// Copyright Joyent, Inc.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pkg/commands/internal/user/init.go
+++ b/pkg/commands/internal/user/init.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Joyent, Inc.
+// Copyright Joyent, Inc.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pkg/commands/internal/user/user.go
+++ b/pkg/commands/internal/user/user.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Joyent, Inc.
+// Copyright Joyent, Inc.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pkg/commands/internal/validation/plan.go
+++ b/pkg/commands/internal/validation/plan.go
@@ -59,7 +59,7 @@ func getValidationPlan(app *cli.Cmd) {
 			util.JSONOut(validationPlan)
 			return
 		}
-		validationPlans := validationPlans{*validationPlan}
+		validationPlans := validationPlans{validationPlan}
 		validationPlans.renderTable()
 	}
 }

--- a/pkg/commands/internal/workspaces/failure.go
+++ b/pkg/commands/internal/workspaces/failure.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Joyent, Inc.
+// Copyright Joyent, Inc.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pkg/commands/internal/workspaces/health.go
+++ b/pkg/commands/internal/workspaces/health.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Joyent, Inc.
+// Copyright Joyent, Inc.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pkg/commands/internal/workspaces/init.go
+++ b/pkg/commands/internal/workspaces/init.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Joyent, Inc.
+// Copyright Joyent, Inc.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pkg/commands/internal/workspaces/workspaces.go
+++ b/pkg/commands/internal/workspaces/workspaces.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Joyent, Inc.
+// Copyright Joyent, Inc.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pkg/conch/conch.go
+++ b/pkg/conch/conch.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Joyent, Inc.
+// Copyright Joyent, Inc.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pkg/conch/conch.go
+++ b/pkg/conch/conch.go
@@ -48,26 +48,17 @@ func (c *Conch) RevokeUserTokens(user string) error {
 		uPart = "email=" + user
 	}
 
-	aerr := &APIError{}
-	res, err := c.sling().Post("/user/"+uPart+"/revoke").Receive(nil, aerr)
-
-	if err := c.isHTTPResOk(res, err, aerr); err != nil {
-		return err
-	}
-
-	return nil
+	return c.post("/user/"+uPart+"/revoke", nil, nil)
 }
 
 // RevokeOwnTokens revokes all auth tokens for the current user. Login() is
 // required after to generate new tokens. Clears the Session, JWToken, and
 // Expires attributes
 func (c *Conch) RevokeOwnTokens() error {
-	aerr := &APIError{}
-	res, err := c.sling().Post("/user/me/revoke").Receive(nil, aerr)
-
-	if err := c.isHTTPResOk(res, err, aerr); err != nil {
+	if err := c.post("/user/me/revoke", nil, nil); err != nil {
 		return err
 	}
+
 	c.Session = ""
 	c.JWToken = ""
 	c.Expires = 0
@@ -108,10 +99,7 @@ func (c *Conch) VerifyLogin(refreshTime int, forceJWT bool) error {
 		Token string `json:"jwt_token,omitempty"`
 	}{}
 
-	aerr := &APIError{}
-	res, err := c.sling().Post("/refresh_token").Receive(&jwtAuth, aerr)
-
-	if err := c.isHTTPResOk(res, err, aerr); err != nil {
+	if err := c.post("/refresh_token", nil, &jwtAuth); err != nil {
 		return err
 	}
 
@@ -155,10 +143,9 @@ func (c *Conch) Login(user string, password string) error {
 		Token string `json:"jwt_token,omitempty"`
 	}{}
 
-	aerr := &APIError{}
-	res, err := c.sling().Post("/login").BodyJSON(payload).Receive(&jwtAuth, aerr)
-	if rerr := c.isHTTPResOk(res, err, aerr); rerr != nil {
-		return rerr
+	res, err := c.postNeedsResponse("/login", payload, &jwtAuth)
+	if err != nil {
+		return err
 	}
 
 	u, _ := url.Parse(c.BaseURL)
@@ -213,9 +200,7 @@ func (c *Conch) ChangePassword(password string) error {
 		Password string `json:"password"`
 	}{password}
 
-	aerr := &APIError{}
-	res, err := c.sling().Post("/user/me/password").BodyJSON(b).Receive(nil, aerr)
-	return c.isHTTPResOk(res, err, aerr)
+	return c.post("/user/me/password", b, nil)
 
 }
 

--- a/pkg/conch/device_settings.go
+++ b/pkg/conch/device_settings.go
@@ -71,11 +71,11 @@ func (c *Conch) SetDeviceSetting(deviceID string, key string, value string) erro
 	j := make(map[string]string)
 	j[key] = value
 
-	aerr := &APIError{}
-	res, err := c.sling().New().Post("/device/"+deviceID+"/settings/"+key).
-		BodyJSON(j).Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.post(
+		"/device/"+deviceID+"/settings/"+key,
+		j,
+		nil,
+	)
 }
 
 // DeleteDeviceSetting deletes a single setting for a device via
@@ -143,11 +143,7 @@ func (c *Conch) SetDeviceTag(deviceID string, key string, value string) error {
 	j := make(map[string]string)
 	j[key] = value
 
-	aerr := &APIError{}
-	res, err := c.sling().New().Post("/device/"+deviceID+"/settings/"+key).
-		BodyJSON(j).Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.post("/device/"+deviceID+"/settings/"+key, j, nil)
 }
 
 // DeleteDeviceTag deletes a single tag for a device via

--- a/pkg/conch/device_settings.go
+++ b/pkg/conch/device_settings.go
@@ -22,17 +22,10 @@ func isTag(str string) bool {
 // Device settings that begin with 'tag.' are filtered out.
 func (c *Conch) GetDeviceSettings(serial string) (map[string]string, error) {
 	settings := make(map[string]string)
-
-	aerr := &APIError{}
-
-	res, err := c.sling().New().
-		Get("/device/"+serial+"/settings").
-		Receive(&settings, aerr)
-
 	filtered := make(map[string]string)
 
-	if ret := c.isHTTPResOk(res, err, aerr); ret != nil {
-		return filtered, ret
+	if err := c.get("/device/"+serial+"/settings", &settings); err != nil {
+		return filtered, err
 	}
 
 	for k, v := range settings {
@@ -56,16 +49,15 @@ func (c *Conch) GetDeviceSetting(serial string, key string) (string, error) {
 	var setting string
 	j := make(map[string]string)
 
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Get("/device/"+serial+"/settings/"+key).
-		Receive(&j, aerr)
+	if err := c.get("/device/"+serial+"/settings/"+key, &j); err != nil {
+		return setting, err
+	}
 
 	if _, ok := j[key]; ok {
 		setting = j[key]
 	}
 
-	return setting, c.isHTTPResOk(res, err, aerr)
+	return setting, nil
 }
 
 // SetDeviceSetting sets a single setting for a device via /device/:deviceID/settings/:key
@@ -106,17 +98,10 @@ func (c *Conch) DeleteDeviceSetting(deviceID string, key string) error {
 // Device settings that do NOT begin with 'tag.' are filtered out.
 func (c *Conch) GetDeviceTags(serial string) (map[string]string, error) {
 	settings := make(map[string]string)
-
-	aerr := &APIError{}
-
-	res, err := c.sling().New().
-		Get("/device/"+serial+"/settings").
-		Receive(&settings, aerr)
-
 	filtered := make(map[string]string)
 
-	if ret := c.isHTTPResOk(res, err, aerr); ret != nil {
-		return filtered, ret
+	if err := c.get("/device/"+serial+"/settings", &settings); err != nil {
+		return filtered, err
 	}
 
 	for k, v := range settings {
@@ -142,16 +127,15 @@ func (c *Conch) GetDeviceTag(serial string, key string) (string, error) {
 	var setting string
 	j := make(map[string]string)
 
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Get("/device/"+serial+"/settings/"+key).
-		Receive(&j, aerr)
+	if err := c.get("/device/"+serial+"/settings/"+key, &j); err != nil {
+		return setting, err
+	}
 
 	if _, ok := j[key]; ok {
 		setting = j[key]
 	}
 
-	return setting, c.isHTTPResOk(res, err, aerr)
+	return setting, nil
 }
 
 // SetDeviceTag sets a single tag for a device via /device/:deviceID/settings/:key

--- a/pkg/conch/device_settings.go
+++ b/pkg/conch/device_settings.go
@@ -86,12 +86,7 @@ func (c *Conch) DeleteDeviceSetting(deviceID string, key string) error {
 	if isTag(key) {
 		return ErrDataNotFound
 	}
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Delete("/device/"+deviceID+"/settings/"+key).
-		Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.httpDelete("/device/" + deviceID + "/settings/" + key)
 }
 
 // GetDeviceTags fetches tags for a device, via /device/:serial/settings
@@ -164,9 +159,5 @@ func (c *Conch) DeleteDeviceTag(deviceID string, key string) error {
 		key = "tag." + key
 	}
 
-	aerr := &APIError{}
-	res, err := c.sling().New().Delete("/device/"+deviceID+"/settings/"+key).
-		Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.httpDelete("/device/" + deviceID + "/settings/" + key)
 }

--- a/pkg/conch/device_settings_test.go
+++ b/pkg/conch/device_settings_test.go
@@ -8,7 +8,6 @@ package conch_test
 
 import (
 	"errors"
-	"github.com/joyent/conch-shell/pkg/conch"
 	"github.com/nbio/st"
 	"gopkg.in/h2non/gock.v1"
 	"testing"
@@ -18,7 +17,9 @@ func TestDeviceSettingsErrors(t *testing.T) {
 	BuildAPI()
 	gock.Flush()
 
-	aerr := conch.APIError{ErrorMsg: "totally broken"}
+	aerr := struct {
+		ErrorMsg string `json:"error"`
+	}{"totally broken"}
 	aerrUnpacked := errors.New(aerr.ErrorMsg)
 
 	t.Run("GetDeviceSettings", func(t *testing.T) {

--- a/pkg/conch/devices.go
+++ b/pkg/conch/devices.go
@@ -448,10 +448,5 @@ func (c *Conch) SaveHardwareProduct(h *HardwareProduct) error {
 // DeleteHardwareProduct deletes a hardware product by marking it as
 // deactivated
 func (c *Conch) DeleteHardwareProduct(hwUUID fmt.Stringer) error {
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Delete("/hardware_product/"+hwUUID.String()).
-		Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.httpDelete("/hardware_product/" + hwUUID.String())
 }

--- a/pkg/conch/devices.go
+++ b/pkg/conch/devices.go
@@ -232,11 +232,10 @@ func (c *Conch) GetWorkspaceDevices(workspaceUUID fmt.Stringer, idsOnly bool, gr
 }
 
 // GetDevice returns a Device given a specific serial/id
-func (c *Conch) GetDevice(serial string) (Device, error) {
-	var device Device
-	device.ID = serial
+func (c *Conch) GetDevice(serial string) (d Device, err error) {
+	d.ID = serial
 
-	return c.FillInDevice(device)
+	return c.FillInDevice(d)
 }
 
 // FillInDevice takes an existing device and fills in its data using "/device"
@@ -250,9 +249,8 @@ func (c *Conch) FillInDevice(d Device) (Device, error) {
 
 // GetDeviceLocation fetches the location for a device, via
 // /device/:serial/location
-func (c *Conch) GetDeviceLocation(serial string) (DeviceLocation, error) {
-	var location DeviceLocation
-	return location, c.get("/device/"+serial+"/location", &location)
+func (c *Conch) GetDeviceLocation(serial string) (loc DeviceLocation, err error) {
+	return loc, c.get("/device/"+serial+"/location", &loc)
 }
 
 // GetWorkspaceRacks fetchest the list of racks for a workspace, via
@@ -283,10 +281,7 @@ func (c *Conch) GetWorkspaceRacks(workspaceUUID fmt.Stringer) ([]Rack, error) {
 func (c *Conch) GetWorkspaceRack(
 	workspaceUUID fmt.Stringer,
 	rackUUID fmt.Stringer,
-) (Rack, error) {
-
-	var rack Rack
-
+) (rack Rack, err error) {
 	return rack, c.get(
 		"/workspace/"+
 			workspaceUUID.String()+
@@ -298,9 +293,10 @@ func (c *Conch) GetWorkspaceRack(
 
 // GetHardwareProduct fetches a single hardware product via
 // /hardware/product/:uuid
-func (c *Conch) GetHardwareProduct(hardwareProductUUID fmt.Stringer) (HardwareProduct, error) {
-	var prod HardwareProduct
-	return prod, c.get("/hardware_product/"+hardwareProductUUID.String(), &prod)
+func (c *Conch) GetHardwareProduct(
+	hardwareProductUUID fmt.Stringer,
+) (hp HardwareProduct, err error) {
+	return hp, c.get("/hardware_product/"+hardwareProductUUID.String(), &hp)
 }
 
 // GetHardwareProducts fetches a single hardware product via

--- a/pkg/conch/devices.go
+++ b/pkg/conch/devices.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Joyent, Inc.
+// Copyright Joyent, Inc.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pkg/conch/devices_test.go
+++ b/pkg/conch/devices_test.go
@@ -19,7 +19,9 @@ func TestDevicesErrors(t *testing.T) {
 	BuildAPI()
 	gock.Flush()
 
-	aerr := conch.APIError{ErrorMsg: "totally broken"}
+	aerr := struct {
+		ErrorMsg string `json:"error"`
+	}{"totally broken"}
 	aerrUnpacked := errors.New(aerr.ErrorMsg)
 
 	t.Run("GetWorkspaceDevices", func(t *testing.T) {

--- a/pkg/conch/errors.go
+++ b/pkg/conch/errors.go
@@ -8,18 +8,7 @@ package conch
 
 import (
 	"errors"
-	"net/http"
 )
-
-//APIError matches the structure of request errors reported by the Conch API
-type APIError struct {
-	ErrorMsg string `json:"error"`
-}
-
-// Return a new error with Conch Error message as the text
-func (ai *APIError) Error() error {
-	return errors.New(ai.ErrorMsg)
-}
 
 var (
 	// ErrLoginFailed indicates that the login process failed for unspecified
@@ -65,39 +54,3 @@ var (
 	// will continue to work for a few minutes.
 	ErrMustChangePassword = errors.New("password must be changed")
 )
-
-// isHTTPResOk is a convenience function to abstract out all the code to see
-// if an API call came back ok.
-func (c *Conch) isHTTPResOk(res *http.Response, err error, aerr *APIError) error {
-	if res == nil {
-		return err
-	}
-
-	if err != nil {
-		return err
-	}
-
-	if res.StatusCode == http.StatusUnauthorized {
-		return ErrNotAuthorized
-	}
-
-	if res.StatusCode == http.StatusForbidden {
-		return ErrForbidden
-	}
-
-	if res.StatusCode == http.StatusNotFound {
-		return ErrDataNotFound
-	}
-
-	if aerr != nil {
-		if aerr.ErrorMsg != "" {
-			return errors.New(aerr.ErrorMsg)
-		}
-	}
-
-	if res.StatusCode >= 400 {
-		return ErrHTTPNotOk
-	}
-
-	return nil
-}

--- a/pkg/conch/errors.go
+++ b/pkg/conch/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Joyent, Inc.
+// Copyright Joyent, Inc.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pkg/conch/errors_test.go
+++ b/pkg/conch/errors_test.go
@@ -18,11 +18,18 @@ func TestErrors(t *testing.T) {
 	BuildAPI()
 	gock.Flush()
 
-	fourohfour := conch.APIError{ErrorMsg: "Not found"}
-	fourohthree := conch.APIError{ErrorMsg: "Forbidden"}
-	fourohone := conch.APIError{ErrorMsg: "Not Authorized"}
-	aerr := conch.APIError{ErrorMsg: "totally broken"}
+	type APIError struct {
+		ErrorMsg string `json:"error"`
+	}
+
+	aerr := struct {
+		ErrorMsg string `json:"error"`
+	}{"totally broken"}
 	aerrUnpacked := errors.New(aerr.ErrorMsg)
+
+	fourohfour := APIError{ErrorMsg: "Not found"}
+	fourohthree := APIError{ErrorMsg: "Forbidden"}
+	fourohone := APIError{ErrorMsg: "Not Authorized"}
 
 	url := "/user/me/settings"
 	gock.New(API.BaseURL).Get(url).Reply(404).JSON(fourohfour)

--- a/pkg/conch/global_datacenter.go
+++ b/pkg/conch/global_datacenter.go
@@ -123,9 +123,7 @@ func (c *Conch) SaveGlobalDatacenter(d *GlobalDatacenter) error {
 
 // DeleteGlobalDatacenter deletes a datacenter
 func (c *Conch) DeleteGlobalDatacenter(id fmt.Stringer) error {
-	aerr := &APIError{}
-	res, err := c.sling().New().Delete("/dc/"+id.String()).Receive(nil, aerr)
-	return c.isHTTPResOk(res, err, aerr)
+	return c.httpDelete("/dc/" + id.String())
 }
 
 // GetGlobalDatacenterRooms gets the global rooms assigned to a global datacenter

--- a/pkg/conch/global_datacenter.go
+++ b/pkg/conch/global_datacenter.go
@@ -73,8 +73,7 @@ func (c *Conch) GetGlobalDatacenters() ([]GlobalDatacenter, error) {
 
 // GetGlobalDatacenter fetches a single datacenter in the global domain, by its
 // UUID
-func (c *Conch) GetGlobalDatacenter(id fmt.Stringer) (GlobalDatacenter, error) {
-	var d GlobalDatacenter
+func (c *Conch) GetGlobalDatacenter(id fmt.Stringer) (d GlobalDatacenter, err error) {
 	return d, c.get("/dc/"+id.String(), &d)
 }
 

--- a/pkg/conch/global_datacenter.go
+++ b/pkg/conch/global_datacenter.go
@@ -69,22 +69,14 @@ type GlobalRackLayoutSlot struct {
 // GetGlobalDatacenters fetches a list of all datacenters in the global domain
 func (c *Conch) GetGlobalDatacenters() ([]GlobalDatacenter, error) {
 	d := make([]GlobalDatacenter, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/dc").Receive(&d, aerr)
-
-	return d, c.isHTTPResOk(res, err, aerr)
+	return d, c.get("/dc", &d)
 }
 
 // GetGlobalDatacenter fetches a single datacenter in the global domain, by its
 // UUID
 func (c *Conch) GetGlobalDatacenter(id fmt.Stringer) (GlobalDatacenter, error) {
-	d := GlobalDatacenter{}
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/dc/"+id.String()).Receive(&d, aerr)
-
-	return d, c.isHTTPResOk(res, err, aerr)
+	var d GlobalDatacenter
+	return d, c.get("/dc/"+id.String(), &d)
 }
 
 // SaveGlobalDatacenter creates or updates a datacenter in the global domain,
@@ -139,9 +131,5 @@ func (c *Conch) DeleteGlobalDatacenter(id fmt.Stringer) error {
 // GetGlobalDatacenterRooms gets the global rooms assigned to a global datacenter
 func (c *Conch) GetGlobalDatacenterRooms(d GlobalDatacenter) ([]GlobalRoom, error) {
 	r := make([]GlobalRoom, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/dc/"+d.ID.String()+"/rooms").Receive(&r, aerr)
-
-	return r, c.isHTTPResOk(res, err, aerr)
+	return r, c.get("/dc/"+d.ID.String()+"/rooms", &r)
 }

--- a/pkg/conch/global_datacenter.go
+++ b/pkg/conch/global_datacenter.go
@@ -9,7 +9,6 @@ package conch
 import (
 	"fmt"
 	uuid "gopkg.in/satori/go.uuid.v1"
-	"net/http"
 	"time"
 )
 
@@ -92,10 +91,6 @@ func (c *Conch) SaveGlobalDatacenter(d *GlobalDatacenter) error {
 		return ErrBadInput
 	}
 
-	var err error
-	var res *http.Response
-	aerr := &APIError{}
-
 	if uuid.Equal(d.ID, uuid.UUID{}) {
 		j := struct {
 			Vendor     string `json:"vendor"`
@@ -104,21 +99,18 @@ func (c *Conch) SaveGlobalDatacenter(d *GlobalDatacenter) error {
 			VendorName string `json:"vendor_name,omitempty"`
 		}{d.Vendor, d.Region, d.Location, d.VendorName}
 
-		res, err = c.sling().New().Post("/dc").BodyJSON(j).Receive(&d, aerr)
+		return c.post("/dc", j, &d)
 	} else {
 		j := struct {
-			ID         string `json:"id"`
+			ID         string `json:"id"` // BUG(sungo): this is probably wrong
 			Vendor     string `json:"vendor,omitempty"`
 			Region     string `json:"region,omitempty"`
 			Location   string `json:"location,omitempty"`
 			VendorName string `json:"vendor_name,omitempty"`
 		}{d.ID.String(), d.Vendor, d.Region, d.Location, d.VendorName}
 
-		res, err = c.sling().New().Post("/dc/"+d.ID.String()).
-			BodyJSON(j).Receive(&d, aerr)
+		return c.post("/dc/"+d.ID.String(), j, &d)
 	}
-
-	return c.isHTTPResOk(res, err, aerr)
 }
 
 // DeleteGlobalDatacenter deletes a datacenter

--- a/pkg/conch/global_datacenter_rack.go
+++ b/pkg/conch/global_datacenter_rack.go
@@ -19,8 +19,7 @@ func (c *Conch) GetGlobalRacks() ([]GlobalRack, error) {
 
 // GetGlobalRack fetches a single rack in the global domain, by its
 // UUID
-func (c *Conch) GetGlobalRack(id fmt.Stringer) (GlobalRack, error) {
-	var r GlobalRack
+func (c *Conch) GetGlobalRack(id fmt.Stringer) (r GlobalRack, err error) {
 	return r, c.get("/rack/"+id.String(), &r)
 }
 

--- a/pkg/conch/global_datacenter_rack.go
+++ b/pkg/conch/global_datacenter_rack.go
@@ -15,22 +15,14 @@ import (
 // GetGlobalRacks fetches a list of all racks in the global domain
 func (c *Conch) GetGlobalRacks() ([]GlobalRack, error) {
 	r := make([]GlobalRack, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/rack").Receive(&r, aerr)
-
-	return r, c.isHTTPResOk(res, err, aerr)
+	return r, c.get("/rack", &r)
 }
 
 // GetGlobalRack fetches a single rack in the global domain, by its
 // UUID
 func (c *Conch) GetGlobalRack(id fmt.Stringer) (GlobalRack, error) {
-	r := GlobalRack{}
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/rack/"+id.String()).Receive(&r, aerr)
-
-	return r, c.isHTTPResOk(res, err, aerr)
+	var r GlobalRack
+	return r, c.get("/rack/"+id.String(), &r)
 }
 
 // SaveGlobalRack creates or updates a rack in the global domain,
@@ -98,10 +90,5 @@ func (c *Conch) DeleteGlobalRack(id fmt.Stringer) error {
 // GetGlobalRackLayout fetches the layout entries for a rack in the global domain
 func (c *Conch) GetGlobalRackLayout(r GlobalRack) ([]GlobalRackLayoutSlot, error) {
 	rs := make([]GlobalRackLayoutSlot, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/rack/"+r.ID.String()+"/layouts").
-		Receive(&rs, aerr)
-
-	return rs, c.isHTTPResOk(res, err, aerr)
+	return rs, c.get("/rack/"+r.ID.String()+"/layouts", &rs)
 }

--- a/pkg/conch/global_datacenter_rack.go
+++ b/pkg/conch/global_datacenter_rack.go
@@ -82,9 +82,7 @@ func (c *Conch) SaveGlobalRack(r *GlobalRack) error {
 
 // DeleteGlobalRack deletes a rack
 func (c *Conch) DeleteGlobalRack(id fmt.Stringer) error {
-	aerr := &APIError{}
-	res, err := c.sling().New().Delete("/rack/"+id.String()).Receive(nil, aerr)
-	return c.isHTTPResOk(res, err, aerr)
+	return c.httpDelete("/rack/" + id.String())
 }
 
 // GetGlobalRackLayout fetches the layout entries for a rack in the global domain

--- a/pkg/conch/global_datacenter_rack.go
+++ b/pkg/conch/global_datacenter_rack.go
@@ -9,7 +9,6 @@ package conch
 import (
 	"fmt"
 	uuid "gopkg.in/satori/go.uuid.v1"
-	"net/http"
 )
 
 // GetGlobalRacks fetches a list of all racks in the global domain
@@ -38,10 +37,6 @@ func (c *Conch) SaveGlobalRack(r *GlobalRack) error {
 		return ErrBadInput
 	}
 
-	var err error
-	var res *http.Response
-	aerr := &APIError{}
-
 	if uuid.Equal(r.ID, uuid.UUID{}) {
 
 		j := struct {
@@ -58,7 +53,7 @@ func (c *Conch) SaveGlobalRack(r *GlobalRack) error {
 			r.AssetTag,
 		}
 
-		res, err = c.sling().New().Post("/rack").BodyJSON(j).Receive(&r, aerr)
+		return c.post("/rack", j, &r)
 	} else {
 		j := struct {
 			DatacenterRoomID string `json:"datacenter_room_id"`
@@ -73,11 +68,9 @@ func (c *Conch) SaveGlobalRack(r *GlobalRack) error {
 			r.SerialNumber,
 			r.AssetTag,
 		}
-		res, err = c.sling().New().Post("/rack/"+r.ID.String()).
-			BodyJSON(j).Receive(&r, aerr)
+		return c.post("/rack/"+r.ID.String(), j, &r)
 	}
 
-	return c.isHTTPResOk(res, err, aerr)
 }
 
 // DeleteGlobalRack deletes a rack

--- a/pkg/conch/global_datacenter_rack_layout.go
+++ b/pkg/conch/global_datacenter_rack_layout.go
@@ -9,7 +9,6 @@ package conch
 import (
 	"fmt"
 	uuid "gopkg.in/satori/go.uuid.v1"
-	"net/http"
 )
 
 // GetGlobalRackLayoutSlots fetches a list of all rack layouts in the global domain
@@ -38,10 +37,6 @@ func (c *Conch) SaveGlobalRackLayoutSlot(r *GlobalRackLayoutSlot) error {
 		return ErrBadInput
 	}
 
-	var err error
-	var res *http.Response
-	aerr := &APIError{}
-
 	j := struct {
 		RackID    string `json:"rack_id"`
 		ProductID string `json:"product_id"`
@@ -53,13 +48,10 @@ func (c *Conch) SaveGlobalRackLayoutSlot(r *GlobalRackLayoutSlot) error {
 	}
 
 	if uuid.Equal(r.ID, uuid.UUID{}) {
-		res, err = c.sling().New().Post("/layout").BodyJSON(j).Receive(&r, aerr)
+		return c.post("/layout", j, &r)
 	} else {
-		res, err = c.sling().New().Post("/layout/"+r.ID.String()).
-			BodyJSON(j).Receive(&r, aerr)
+		return c.post("/layout/"+r.ID.String(), j, &r)
 	}
-
-	return c.isHTTPResOk(res, err, aerr)
 }
 
 // DeleteGlobalRackLayoutSlot deletes a rack layout

--- a/pkg/conch/global_datacenter_rack_layout.go
+++ b/pkg/conch/global_datacenter_rack_layout.go
@@ -15,22 +15,14 @@ import (
 // GetGlobalRackLayoutSlots fetches a list of all rack layouts in the global domain
 func (c *Conch) GetGlobalRackLayoutSlots() ([]GlobalRackLayoutSlot, error) {
 	r := make([]GlobalRackLayoutSlot, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/layout").Receive(&r, aerr)
-
-	return r, c.isHTTPResOk(res, err, aerr)
+	return r, c.get("/layout", &r)
 }
 
 // GetGlobalRackLayoutSlot fetches a single rack layout in the global domain, by its
 // UUID
 func (c *Conch) GetGlobalRackLayoutSlot(id fmt.Stringer) (*GlobalRackLayoutSlot, error) {
 	r := &GlobalRackLayoutSlot{}
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/layout/"+id.String()).Receive(&r, aerr)
-
-	return r, c.isHTTPResOk(res, err, aerr)
+	return r, c.get("/layout/"+id.String(), &r)
 }
 
 // SaveGlobalRackLayoutSlot creates or updates a rack layout in the global domain,

--- a/pkg/conch/global_datacenter_rack_layout.go
+++ b/pkg/conch/global_datacenter_rack_layout.go
@@ -64,7 +64,5 @@ func (c *Conch) SaveGlobalRackLayoutSlot(r *GlobalRackLayoutSlot) error {
 
 // DeleteGlobalRackLayoutSlot deletes a rack layout
 func (c *Conch) DeleteGlobalRackLayoutSlot(id fmt.Stringer) error {
-	aerr := &APIError{}
-	res, err := c.sling().New().Delete("/layout/"+id.String()).Receive(nil, aerr)
-	return c.isHTTPResOk(res, err, aerr)
+	return c.httpDelete("/layout/" + id.String())
 }

--- a/pkg/conch/global_datacenter_rack_layout_test.go
+++ b/pkg/conch/global_datacenter_rack_layout_test.go
@@ -19,7 +19,9 @@ func TestGlobalRackLayoutSlotErrors(t *testing.T) {
 	BuildAPI()
 	gock.Flush()
 
-	aerr := conch.APIError{ErrorMsg: "totally broken"}
+	aerr := struct {
+		ErrorMsg string `json:"error"`
+	}{"totally broken"}
 	aerrUnpacked := errors.New(aerr.ErrorMsg)
 
 	t.Run("GetGlobalRackLayoutSlots", func(t *testing.T) {

--- a/pkg/conch/global_datacenter_rack_role.go
+++ b/pkg/conch/global_datacenter_rack_role.go
@@ -15,22 +15,14 @@ import (
 // GetGlobalRackRoles fetches a list of all rack roles in the global domain
 func (c *Conch) GetGlobalRackRoles() ([]GlobalRackRole, error) {
 	r := make([]GlobalRackRole, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/rack_role").Receive(&r, aerr)
-
-	return r, c.isHTTPResOk(res, err, aerr)
+	return r, c.get("/rack_role", &r)
 }
 
 // GetGlobalRackRole fetches a single rack role in the global domain, by its
 // UUID
-func (c *Conch) GetGlobalRackRole(id fmt.Stringer) (*GlobalRackRole, error) {
-	r := &GlobalRackRole{}
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/rack_role/"+id.String()).Receive(&r, aerr)
-
-	return r, c.isHTTPResOk(res, err, aerr)
+func (c *Conch) GetGlobalRackRole(id fmt.Stringer) (GlobalRackRole, error) {
+	var r GlobalRackRole
+	return r, c.get("/rack_role/"+id.String(), &r)
 }
 
 // SaveGlobalRackRole creates or updates a rack role in the global domain,

--- a/pkg/conch/global_datacenter_rack_role.go
+++ b/pkg/conch/global_datacenter_rack_role.go
@@ -19,8 +19,7 @@ func (c *Conch) GetGlobalRackRoles() ([]GlobalRackRole, error) {
 
 // GetGlobalRackRole fetches a single rack role in the global domain, by its
 // UUID
-func (c *Conch) GetGlobalRackRole(id fmt.Stringer) (GlobalRackRole, error) {
-	var r GlobalRackRole
+func (c *Conch) GetGlobalRackRole(id fmt.Stringer) (r GlobalRackRole, err error) {
 	return r, c.get("/rack_role/"+id.String(), &r)
 }
 

--- a/pkg/conch/global_datacenter_rack_role.go
+++ b/pkg/conch/global_datacenter_rack_role.go
@@ -70,7 +70,5 @@ func (c *Conch) SaveGlobalRackRole(r *GlobalRackRole) error {
 
 // DeleteGlobalRackRole deletes a rack role
 func (c *Conch) DeleteGlobalRackRole(id fmt.Stringer) error {
-	aerr := &APIError{}
-	res, err := c.sling().New().Delete("/rack_role/"+id.String()).Receive(nil, aerr)
-	return c.isHTTPResOk(res, err, aerr)
+	return c.httpDelete("/rack_role/" + id.String())
 }

--- a/pkg/conch/global_datacenter_rack_role_test.go
+++ b/pkg/conch/global_datacenter_rack_role_test.go
@@ -39,7 +39,7 @@ func TestGlobalRackRoleErrors(t *testing.T) {
 
 		ret, err := API.GetGlobalRackRole(id)
 		st.Expect(t, err, aerrUnpacked)
-		st.Expect(t, ret, &conch.GlobalRackRole{})
+		st.Expect(t, ret, conch.GlobalRackRole{})
 	})
 
 	t.Run("CreateGlobalRackRole", func(t *testing.T) {

--- a/pkg/conch/global_datacenter_rack_role_test.go
+++ b/pkg/conch/global_datacenter_rack_role_test.go
@@ -19,7 +19,9 @@ func TestGlobalRackRoleErrors(t *testing.T) {
 	BuildAPI()
 	gock.Flush()
 
-	aerr := conch.APIError{ErrorMsg: "totally broken"}
+	aerr := struct {
+		ErrorMsg string `json:"error"`
+	}{"totally broken"}
 	aerrUnpacked := errors.New(aerr.ErrorMsg)
 
 	t.Run("GetGlobalRackRoles", func(t *testing.T) {

--- a/pkg/conch/global_datacenter_rack_test.go
+++ b/pkg/conch/global_datacenter_rack_test.go
@@ -19,7 +19,9 @@ func TestGlobalRackErrors(t *testing.T) {
 	BuildAPI()
 	gock.Flush()
 
-	aerr := conch.APIError{ErrorMsg: "totally broken"}
+	aerr := struct {
+		ErrorMsg string `json:"error"`
+	}{"totally broken"}
 	aerrUnpacked := errors.New(aerr.ErrorMsg)
 
 	t.Run("GetGlobalRacks", func(t *testing.T) {

--- a/pkg/conch/global_datacenter_room.go
+++ b/pkg/conch/global_datacenter_room.go
@@ -15,22 +15,14 @@ import (
 // GetGlobalRooms fetches a list of all rooms in the global domain
 func (c *Conch) GetGlobalRooms() ([]GlobalRoom, error) {
 	r := make([]GlobalRoom, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/room").Receive(&r, aerr)
-
-	return r, c.isHTTPResOk(res, err, aerr)
+	return r, c.get("/room", &r)
 }
 
 // GetGlobalRoom fetches a single room in the global domain, by its
 // UUID
 func (c *Conch) GetGlobalRoom(id fmt.Stringer) (GlobalRoom, error) {
-	r := GlobalRoom{}
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/room/"+id.String()).Receive(&r, aerr)
-
-	return r, c.isHTTPResOk(res, err, aerr)
+	var r GlobalRoom
+	return r, c.get("/room/"+id.String(), &r)
 }
 
 // SaveGlobalRoom creates or updates a room in the global domain,
@@ -83,10 +75,5 @@ func (c *Conch) DeleteGlobalRoom(id fmt.Stringer) error {
 // domain
 func (c *Conch) GetGlobalRoomRacks(r GlobalRoom) ([]GlobalRack, error) {
 	rs := make([]GlobalRack, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/room/"+r.ID.String()+"/racks").
-		Receive(&rs, aerr)
-
-	return rs, c.isHTTPResOk(res, err, aerr)
+	return rs, c.get("/room/"+r.ID.String()+"/racks", &rs)
 }

--- a/pkg/conch/global_datacenter_room.go
+++ b/pkg/conch/global_datacenter_room.go
@@ -66,9 +66,7 @@ func (c *Conch) SaveGlobalRoom(r *GlobalRoom) error {
 
 // DeleteGlobalRoom deletes a room
 func (c *Conch) DeleteGlobalRoom(id fmt.Stringer) error {
-	aerr := &APIError{}
-	res, err := c.sling().New().Delete("/room/"+id.String()).Receive(nil, aerr)
-	return c.isHTTPResOk(res, err, aerr)
+	return c.httpDelete("/room/" + id.String())
 }
 
 // GetGlobalRoomRacks retrieves the racks assigned to a room in the global

--- a/pkg/conch/global_datacenter_room.go
+++ b/pkg/conch/global_datacenter_room.go
@@ -19,8 +19,7 @@ func (c *Conch) GetGlobalRooms() ([]GlobalRoom, error) {
 
 // GetGlobalRoom fetches a single room in the global domain, by its
 // UUID
-func (c *Conch) GetGlobalRoom(id fmt.Stringer) (GlobalRoom, error) {
-	var r GlobalRoom
+func (c *Conch) GetGlobalRoom(id fmt.Stringer) (r GlobalRoom, err error) {
 	return r, c.get("/room/"+id.String(), &r)
 }
 

--- a/pkg/conch/global_datacenter_room_test.go
+++ b/pkg/conch/global_datacenter_room_test.go
@@ -19,7 +19,9 @@ func TestGlobalRoomErrors(t *testing.T) {
 	BuildAPI()
 	gock.Flush()
 
-	aerr := conch.APIError{ErrorMsg: "totally broken"}
+	aerr := struct {
+		ErrorMsg string `json:"error"`
+	}{"totally broken"}
 	aerrUnpacked := errors.New(aerr.ErrorMsg)
 
 	t.Run("GetGlobalRooms", func(t *testing.T) {

--- a/pkg/conch/global_datacenter_test.go
+++ b/pkg/conch/global_datacenter_test.go
@@ -19,7 +19,9 @@ func TestGlobalDatacenterErrors(t *testing.T) {
 	BuildAPI()
 	gock.Flush()
 
-	aerr := conch.APIError{ErrorMsg: "totally broken"}
+	aerr := struct {
+		ErrorMsg string `json:"error"`
+	}{"totally broken"}
 	aerrUnpacked := errors.New(aerr.ErrorMsg)
 
 	t.Run("GetGlobalDatacenters", func(t *testing.T) {

--- a/pkg/conch/hardware_vendor.go
+++ b/pkg/conch/hardware_vendor.go
@@ -33,11 +33,7 @@ func (c *Conch) GetHardwareVendors() ([]HardwareVendor, error) {
 
 // DeleteHardwareVendor ...
 func (c *Conch) DeleteHardwareVendor(name string) error {
-	aerr := &APIError{}
-	res, err := c.sling().New().Delete("/hardware_vendor/"+name).
-		Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.httpDelete("/hardware_vendor/" + name)
 }
 
 // SaveHardwareVendor ...

--- a/pkg/conch/hardware_vendor.go
+++ b/pkg/conch/hardware_vendor.go
@@ -22,22 +22,13 @@ type HardwareVendor struct {
 // GetHardwareVendor ...
 func (c *Conch) GetHardwareVendor(name string) (HardwareVendor, error) {
 	var vendor HardwareVendor
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/hardware_vendor/"+name).
-		Receive(&vendor, aerr)
-
-	return vendor, c.isHTTPResOk(res, err, aerr)
+	return vendor, c.get("/hardware_vendor/"+name, &vendor)
 }
 
 // GetHardwareVendors ...
 func (c *Conch) GetHardwareVendors() ([]HardwareVendor, error) {
 	vendors := make([]HardwareVendor, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/hardware_vendor").Receive(&vendors, aerr)
-
-	return vendors, c.isHTTPResOk(res, err, aerr)
+	return vendors, c.get("/hardware_vendor", &vendors)
 }
 
 // DeleteHardwareVendor ...

--- a/pkg/conch/hardware_vendor.go
+++ b/pkg/conch/hardware_vendor.go
@@ -20,9 +20,8 @@ type HardwareVendor struct {
 }
 
 // GetHardwareVendor ...
-func (c *Conch) GetHardwareVendor(name string) (HardwareVendor, error) {
-	var vendor HardwareVendor
-	return vendor, c.get("/hardware_vendor/"+name, &vendor)
+func (c *Conch) GetHardwareVendor(name string) (v HardwareVendor, err error) {
+	return v, c.get("/hardware_vendor/"+name, &v)
 }
 
 // GetHardwareVendors ...

--- a/pkg/conch/hardware_vendor.go
+++ b/pkg/conch/hardware_vendor.go
@@ -46,14 +46,13 @@ func (c *Conch) SaveHardwareVendor(v *HardwareVendor) error {
 		return ErrBadInput
 	}
 
-	aerr := &APIError{}
-
 	out := struct {
 		Name string `json:"name"`
 	}{v.Name}
 
-	res, err := c.sling().New().Post("/hardware_vendor/"+v.Name).BodyJSON(out).
-		Receive(&v, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.post(
+		"/hardware_vendor/"+v.Name,
+		out,
+		&v,
+	)
 }

--- a/pkg/conch/hardware_vendor_test.go
+++ b/pkg/conch/hardware_vendor_test.go
@@ -18,7 +18,9 @@ func TestHardwareVendorErrors(t *testing.T) {
 	BuildAPI()
 	gock.Flush()
 
-	aerr := conch.APIError{ErrorMsg: "totally broken"}
+	aerr := struct {
+		ErrorMsg string `json:"error"`
+	}{"totally broken"}
 	aerrUnpacked := errors.New(aerr.ErrorMsg)
 
 	name := "hardware vendor"

--- a/pkg/conch/relays.go
+++ b/pkg/conch/relays.go
@@ -97,13 +97,11 @@ func (c *Conch) RegisterRelay(r WorkspaceRelay) error {
 		r.Version,
 	}
 
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Post("/relay/"+r.ID+"/register").
-		BodyJSON(d).
-		Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.post(
+		"/relay/"+r.ID+"/register",
+		d,
+		nil,
+	)
 }
 
 // GetAllRelays uses the /relay endpoint to get a list of all

--- a/pkg/conch/relays.go
+++ b/pkg/conch/relays.go
@@ -55,24 +55,15 @@ func (c *Conch) GetActiveWorkspaceRelays(
 		minutes,
 	)
 
-	aerr := &APIError{}
-	res, err := c.sling().New().Get(url).Receive(&relays, aerr)
-
-	return relays, c.isHTTPResOk(res, err, aerr)
+	return relays, c.get(url, &relays)
 }
 
 // GetWorkspaceRelays returns all Relays associated with the given workspace
 func (c *Conch) GetWorkspaceRelays(workspaceUUID fmt.Stringer) ([]WorkspaceRelay, error) {
-	var err error
-
 	relays := make([]WorkspaceRelay, 0)
 
 	url := "/workspace/" + workspaceUUID.String() + "/relay"
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get(url).Receive(&relays, aerr)
-
-	return relays, c.isHTTPResOk(res, err, aerr)
+	return relays, c.get(url, &relays)
 }
 
 // GetWorkspaceRelayDevices ...
@@ -80,13 +71,10 @@ func (c *Conch) GetWorkspaceRelayDevices(
 	workspaceUUID fmt.Stringer,
 	relayName string,
 ) ([]Device, error) {
+
 	devices := make([]Device, 0)
 	url := "/workspace/" + workspaceUUID.String() + "/relay/" + relayName + "/device"
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get(url).Receive(&devices, aerr)
-
-	return devices, c.isHTTPResOk(res, err, aerr)
+	return devices, c.get(url, &devices)
 }
 
 // RegisterRelay registers/updates a Relay via /relay/:serial/register
@@ -122,8 +110,5 @@ func (c *Conch) RegisterRelay(r WorkspaceRelay) error {
 // relays, but without their assigned devices.
 func (c *Conch) GetAllRelays() ([]WorkspaceRelay, error) {
 	relays := make([]WorkspaceRelay, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/relay?no_devices=1").Receive(&relays, aerr)
-	return relays, c.isHTTPResOk(res, err, aerr)
+	return relays, c.get("/relay?no_devices=1", &relays)
 }

--- a/pkg/conch/relays_test.go
+++ b/pkg/conch/relays_test.go
@@ -19,7 +19,9 @@ func TestRelayErrors(t *testing.T) {
 	BuildAPI()
 	gock.Flush()
 
-	aerr := conch.APIError{ErrorMsg: "totally broken"}
+	aerr := struct {
+		ErrorMsg string `json:"error"`
+	}{"totally broken"}
 	aerrUnpacked := errors.New(aerr.ErrorMsg)
 
 	t.Run("GetWorkspaceRelays", func(t *testing.T) {

--- a/pkg/conch/sling.go
+++ b/pkg/conch/sling.go
@@ -132,6 +132,12 @@ func (c *Conch) get(url string, data interface{}) error {
 	return c.isHTTPResOk(res, err, aerr)
 }
 
+func (c *Conch) getWithQuery(url string, query interface{}, data interface{}) error {
+	aerr := &APIError{}
+	res, err := c.sling().New().Get(url).QueryStruct(query).Receive(data, aerr)
+	return c.isHTTPResOk(res, err, aerr)
+}
+
 // RawGet allows the user to perform an HTTP GET against the API, with the
 // library handling all auth but *not* processing the response.
 func (c *Conch) RawGet(url string) (*http.Response, error) {

--- a/pkg/conch/sling.go
+++ b/pkg/conch/sling.go
@@ -138,6 +138,12 @@ func (c *Conch) getWithQuery(url string, query interface{}, data interface{}) er
 	return c.isHTTPResOk(res, err, aerr)
 }
 
+func (c *Conch) httpDelete(url string) error {
+	aerr := &APIError{}
+	res, err := c.sling().New().Delete(url).Receive(nil, aerr)
+	return c.isHTTPResOk(res, err, aerr)
+}
+
 // RawGet allows the user to perform an HTTP GET against the API, with the
 // library handling all auth but *not* processing the response.
 func (c *Conch) RawGet(url string) (*http.Response, error) {

--- a/pkg/conch/sling.go
+++ b/pkg/conch/sling.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Joyent, Inc.
+// Copyright Joyent, Inc.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pkg/conch/sling.go
+++ b/pkg/conch/sling.go
@@ -126,6 +126,12 @@ func (c *Conch) sling() *sling.Sling {
 	return s
 }
 
+func (c *Conch) get(url string, data interface{}) error {
+	aerr := &APIError{}
+	res, err := c.sling().New().Get(url).Receive(data, aerr)
+	return c.isHTTPResOk(res, err, aerr)
+}
+
 // RawGet allows the user to perform an HTTP GET against the API, with the
 // library handling all auth but *not* processing the response.
 func (c *Conch) RawGet(url string) (*http.Response, error) {

--- a/pkg/conch/sling.go
+++ b/pkg/conch/sling.go
@@ -144,6 +144,32 @@ func (c *Conch) httpDelete(url string) error {
 	return c.isHTTPResOk(res, err, aerr)
 }
 
+func (c *Conch) post(url string, payload interface{}, response interface{}) error {
+	aerr := &APIError{}
+	res, err := c.sling().New().
+		Post(url).
+		BodyJSON(payload).
+		Receive(response, aerr)
+
+	return c.isHTTPResOk(res, err, aerr)
+}
+
+func (c *Conch) postNeedsResponse(
+	url string,
+	payload interface{},
+	response interface{},
+
+) (*http.Response, error) {
+
+	aerr := &APIError{}
+	res, err := c.sling().New().
+		Post(url).
+		BodyJSON(payload).
+		Receive(response, aerr)
+
+	return res, c.isHTTPResOk(res, err, aerr)
+}
+
 // RawGet allows the user to perform an HTTP GET against the API, with the
 // library handling all auth but *not* processing the response.
 func (c *Conch) RawGet(url string) (*http.Response, error) {

--- a/pkg/conch/user.go
+++ b/pkg/conch/user.go
@@ -46,8 +46,7 @@ func (c *Conch) GetUserSettings() (map[string]interface{}, error) {
 // The return is an interface{} because the database structure is a string name
 // and a jsonb data field.  There is no way for this library to know in
 // advanace what's in that data so here there be dragons.
-func (c *Conch) GetUserSetting(key string) (interface{}, error) {
-	var setting interface{}
+func (c *Conch) GetUserSetting(key string) (setting interface{}, err error) {
 	return setting, c.get("/user/me/settings/"+key, &setting)
 }
 

--- a/pkg/conch/user.go
+++ b/pkg/conch/user.go
@@ -53,24 +53,12 @@ func (c *Conch) GetUserSetting(key string) (interface{}, error) {
 
 // SetUserSettings sets the value of *all* user settings via /user/me/settings
 func (c *Conch) SetUserSettings(settings map[string]interface{}) error {
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Post("/user/me/settings").
-		BodyJSON(settings).
-		Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.post("/user/me/settings", settings, nil)
 }
 
 // SetUserSetting sets the value of a user setting via /user/me/settings/:name
 func (c *Conch) SetUserSetting(name string, value interface{}) error {
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Post("/user/me/settings/"+name).
-		BodyJSON(value).
-		Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.post("/user/me/settings/"+name, value, nil)
 }
 
 // DeleteUserSetting deletes a user setting via /user/me/settings/:name
@@ -99,10 +87,7 @@ func (c *Conch) CreateUser(email string, password string, name string) error {
 		Name     string `json:"name,omitempty"`
 	}{email, password, name}
 
-	aerr := &APIError{}
-	res, err := c.sling().New().Post("/user").BodyJSON(u).Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.post("/user", u, nil)
 }
 
 // ResetUserPassword resets the password for the provided user, causing an

--- a/pkg/conch/user.go
+++ b/pkg/conch/user.go
@@ -39,10 +39,7 @@ type UserDetailed struct {
 // know in advanace what's in that data so here there be dragons.
 func (c *Conch) GetUserSettings() (map[string]interface{}, error) {
 	settings := make(map[string]interface{})
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/user/me/settings").Receive(&settings, aerr)
-	return settings, c.isHTTPResOk(res, err, aerr)
+	return settings, c.get("/user/me/settings", &settings)
 }
 
 // GetUserSetting returns the results of /user/me/settings/:key
@@ -51,12 +48,7 @@ func (c *Conch) GetUserSettings() (map[string]interface{}, error) {
 // advanace what's in that data so here there be dragons.
 func (c *Conch) GetUserSetting(key string) (interface{}, error) {
 	var setting interface{}
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/user/me/settings/"+key).
-		Receive(&setting, aerr)
-
-	return setting, c.isHTTPResOk(res, err, aerr)
+	return setting, c.get("/user/me/settings/"+key, &setting)
 }
 
 // SetUserSettings sets the value of *all* user settings via /user/me/settings
@@ -134,8 +126,5 @@ func (c *Conch) ResetUserPassword(email string) error {
 // permissions, in the system. Returns UserDetailed structs
 func (c *Conch) GetAllUsers() ([]UserDetailed, error) {
 	u := make([]UserDetailed, 0)
-	aerr := &APIError{}
-
-	res, err := c.sling().New().Get("/user").Receive(&u, aerr)
-	return u, c.isHTTPResOk(res, err, aerr)
+	return u, c.get("/user", &u)
 }

--- a/pkg/conch/user.go
+++ b/pkg/conch/user.go
@@ -75,12 +75,7 @@ func (c *Conch) SetUserSetting(name string, value interface{}) error {
 
 // DeleteUserSetting deletes a user setting via /user/me/settings/:name
 func (c *Conch) DeleteUserSetting(name string) error {
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Delete("/user/me/settings/"+name).
-		Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.httpDelete("/user/me/settings/" + name)
 }
 
 // DeleteUser deletes a user and, optionally, clears their JWT credentials
@@ -91,10 +86,7 @@ func (c *Conch) DeleteUser(emailAddress string, clearTokens bool) error {
 		url = url + "?clear_tokens=1"
 	}
 
-	aerr := &APIError{}
-	res, err := c.sling().New().Delete(url).Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.httpDelete(url)
 }
 
 // CreateUser creates a new user. They are *not* added to a workspace.
@@ -116,10 +108,7 @@ func (c *Conch) CreateUser(email string, password string, name string) error {
 // ResetUserPassword resets the password for the provided user, causing an
 // email to be sent
 func (c *Conch) ResetUserPassword(email string) error {
-	aerr := &APIError{}
-	res, err := c.sling().New().Delete("/user/email="+email+"/password").Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.httpDelete("/user/email=" + email + "/password")
 }
 
 // GetAllUsers retrieves a list of all users, if the user has the right

--- a/pkg/conch/user_test.go
+++ b/pkg/conch/user_test.go
@@ -18,7 +18,9 @@ func TestUserErrors(t *testing.T) {
 	BuildAPI()
 	gock.Flush()
 
-	aerr := conch.APIError{ErrorMsg: "totally broken"}
+	aerr := struct {
+		ErrorMsg string `json:"error"`
+	}{"totally broken"}
 	aerrUnpacked := errors.New(aerr.ErrorMsg)
 
 	t.Run("GetUserSettings", func(t *testing.T) {

--- a/pkg/conch/validations.go
+++ b/pkg/conch/validations.go
@@ -59,34 +59,25 @@ type ValidationState struct {
 // validations loaded in the system
 func (c *Conch) GetValidations() ([]Validation, error) {
 	validations := make([]Validation, 0)
-	aerr := &APIError{}
-
-	res, err := c.sling().New().Get("/validation").Receive(&validations, aerr)
-	return validations, c.isHTTPResOk(res, err, aerr)
+	return validations, c.get("/validation", &validations)
 }
 
 // GetValidationPlans returns the contents of /validation_plan, getting the
 // list of all validations plans loaded in the system
 func (c *Conch) GetValidationPlans() ([]ValidationPlan, error) {
 	validationPlans := make([]ValidationPlan, 0)
-	aerr := &APIError{}
-
-	res, err := c.sling().New().Get("/validation_plan").
-		Receive(&validationPlans, aerr)
-	return validationPlans, c.isHTTPResOk(res, err, aerr)
+	return validationPlans, c.get("/validation_plan", &validationPlans)
 }
 
 // GetValidationPlan returns the contents of /validation_plan/:uuid, getting information
 // about a single validation plan
+// BUG(sungo): why is this returning a pointer?
 func (c *Conch) GetValidationPlan(validationPlanUUID fmt.Stringer) (*ValidationPlan, error) {
-	validationPlan := &ValidationPlan{}
-
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Get("/validation_plan/"+validationPlanUUID.String()).
-		Receive(validationPlan, aerr)
-
-	return validationPlan, c.isHTTPResOk(res, err, aerr)
+	var validationPlan ValidationPlan
+	return &validationPlan, c.get(
+		"/validation_plan/"+validationPlanUUID.String(),
+		&validationPlan,
+	)
 }
 
 // CreateValidationPlan creates a new validation plan in Conch
@@ -140,13 +131,10 @@ func (c *Conch) RemoveValidationFromPlan(validationPlanUUID fmt.Stringer, valida
 // GetValidationPlanValidations gets the list of validations associated with a validation plan
 func (c *Conch) GetValidationPlanValidations(validationPlanUUID fmt.Stringer) ([]Validation, error) {
 	validations := make([]Validation, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Get("/validation_plan/"+validationPlanUUID.String()+"/validation").
-		Receive(&validations, aerr)
-
-	return validations, c.isHTTPResOk(res, err, aerr)
+	return validations, c.get(
+		"/validation_plan/"+validationPlanUUID.String()+"/validation",
+		&validations,
+	)
 }
 
 // RunDeviceValidation runs a validation against given a device and returns the results
@@ -178,23 +166,14 @@ func (c *Conch) RunDeviceValidationPlan(deviceSerial string, validationPlanUUID 
 // DeviceValidationStates returns the stored validation states for a device
 func (c *Conch) DeviceValidationStates(deviceSerial string) ([]ValidationState, error) {
 	states := make([]ValidationState, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Get("/device/"+deviceSerial+"/validation_state").
-		Receive(&states, aerr)
-
-	return states, c.isHTTPResOk(res, err, aerr)
+	return states, c.get("/device/"+deviceSerial+"/validation_state", &states)
 }
 
 // WorkspaceValidationStates returns the stored validation states for all devices in a workspace
 func (c *Conch) WorkspaceValidationStates(workspaceUUID fmt.Stringer) ([]ValidationState, error) {
 	states := make([]ValidationState, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Get("/workspace/"+workspaceUUID.String()+"/validation_state").
-		Receive(&states, aerr)
-
-	return states, c.isHTTPResOk(res, err, aerr)
+	return states, c.get(
+		"/workspace/"+workspaceUUID.String()+"/validation_state",
+		&states,
+	)
 }

--- a/pkg/conch/validations.go
+++ b/pkg/conch/validations.go
@@ -72,16 +72,21 @@ func (c *Conch) GetValidationPlans() ([]ValidationPlan, error) {
 // GetValidationPlan returns the contents of /validation_plan/:uuid, getting information
 // about a single validation plan
 // BUG(sungo): why is this returning a pointer?
-func (c *Conch) GetValidationPlan(validationPlanUUID fmt.Stringer) (*ValidationPlan, error) {
-	var validationPlan ValidationPlan
-	return &validationPlan, c.get(
+func (c *Conch) GetValidationPlan(
+	validationPlanUUID fmt.Stringer,
+) (*ValidationPlan, error) {
+	var vp ValidationPlan
+
+	return &vp, c.get(
 		"/validation_plan/"+validationPlanUUID.String(),
-		&validationPlan,
+		&vp,
 	)
 }
 
 // CreateValidationPlan creates a new validation plan in Conch
-func (c *Conch) CreateValidationPlan(newValidationPlan ValidationPlan) (ValidationPlan, error) {
+func (c *Conch) CreateValidationPlan(
+	newValidationPlan ValidationPlan,
+) (ValidationPlan, error) {
 
 	j := struct {
 		Name        string `json:"name"`
@@ -95,7 +100,10 @@ func (c *Conch) CreateValidationPlan(newValidationPlan ValidationPlan) (Validati
 }
 
 // AddValidationToPlan associates a validation with a validation plan
-func (c *Conch) AddValidationToPlan(validationPlanUUID fmt.Stringer, validationUUID fmt.Stringer) error {
+func (c *Conch) AddValidationToPlan(
+	validationPlanUUID fmt.Stringer,
+	validationUUID fmt.Stringer,
+) error {
 	j := struct {
 		ID string `json:"id"`
 	}{
@@ -110,7 +118,10 @@ func (c *Conch) AddValidationToPlan(validationPlanUUID fmt.Stringer, validationU
 }
 
 // RemoveValidationFromPlan removes a validation from a validation plan
-func (c *Conch) RemoveValidationFromPlan(validationPlanUUID fmt.Stringer, validationUUID fmt.Stringer) error {
+func (c *Conch) RemoveValidationFromPlan(
+	validationPlanUUID fmt.Stringer,
+	validationUUID fmt.Stringer,
+) error {
 
 	return c.httpDelete(
 		"/validation_plan/" +
@@ -121,7 +132,10 @@ func (c *Conch) RemoveValidationFromPlan(validationPlanUUID fmt.Stringer, valida
 }
 
 // GetValidationPlanValidations gets the list of validations associated with a validation plan
-func (c *Conch) GetValidationPlanValidations(validationPlanUUID fmt.Stringer) ([]Validation, error) {
+func (c *Conch) GetValidationPlanValidations(
+	validationPlanUUID fmt.Stringer,
+) ([]Validation, error) {
+
 	validations := make([]Validation, 0)
 	return validations, c.get(
 		"/validation_plan/"+validationPlanUUID.String()+"/validation",
@@ -130,7 +144,13 @@ func (c *Conch) GetValidationPlanValidations(validationPlanUUID fmt.Stringer) ([
 }
 
 // RunDeviceValidation runs a validation against given a device and returns the results
-func (c *Conch) RunDeviceValidation(deviceSerial string, validationUUID fmt.Stringer, body io.Reader) ([]ValidationResult, error) {
+// BUG(sungo): this is taking an io.Reader and trusting upstream to read it and close it. Knock that off.
+func (c *Conch) RunDeviceValidation(
+	deviceSerial string,
+	validationUUID fmt.Stringer,
+	body io.Reader,
+) ([]ValidationResult, error) {
+
 	results := make([]ValidationResult, 0)
 
 	return results, c.post(
@@ -141,7 +161,13 @@ func (c *Conch) RunDeviceValidation(deviceSerial string, validationUUID fmt.Stri
 }
 
 // RunDeviceValidationPlan runs a validation plan against a given device and returns the results
-func (c *Conch) RunDeviceValidationPlan(deviceSerial string, validationPlanUUID fmt.Stringer, body io.Reader) ([]ValidationResult, error) {
+// BUG(sungo): this is taking an io.Reader and trusting upstream to read it and close it. Knock that off.
+func (c *Conch) RunDeviceValidationPlan(
+	deviceSerial string,
+	validationPlanUUID fmt.Stringer,
+	body io.Reader,
+) ([]ValidationResult, error) {
+
 	results := make([]ValidationResult, 0)
 	return results, c.post(
 		"/device/"+deviceSerial+"/validation_plan/"+validationPlanUUID.String(),
@@ -151,13 +177,19 @@ func (c *Conch) RunDeviceValidationPlan(deviceSerial string, validationPlanUUID 
 }
 
 // DeviceValidationStates returns the stored validation states for a device
-func (c *Conch) DeviceValidationStates(deviceSerial string) ([]ValidationState, error) {
+func (c *Conch) DeviceValidationStates(
+	deviceSerial string,
+) ([]ValidationState, error) {
+
 	states := make([]ValidationState, 0)
 	return states, c.get("/device/"+deviceSerial+"/validation_state", &states)
 }
 
 // WorkspaceValidationStates returns the stored validation states for all devices in a workspace
-func (c *Conch) WorkspaceValidationStates(workspaceUUID fmt.Stringer) ([]ValidationState, error) {
+func (c *Conch) WorkspaceValidationStates(
+	workspaceUUID fmt.Stringer,
+) ([]ValidationState, error) {
+
 	states := make([]ValidationState, 0)
 	return states, c.get(
 		"/workspace/"+workspaceUUID.String()+"/validation_state",

--- a/pkg/conch/validations.go
+++ b/pkg/conch/validations.go
@@ -71,13 +71,11 @@ func (c *Conch) GetValidationPlans() ([]ValidationPlan, error) {
 
 // GetValidationPlan returns the contents of /validation_plan/:uuid, getting information
 // about a single validation plan
-// BUG(sungo): why is this returning a pointer?
 func (c *Conch) GetValidationPlan(
 	validationPlanUUID fmt.Stringer,
-) (*ValidationPlan, error) {
-	var vp ValidationPlan
+) (vp ValidationPlan, err error) {
 
-	return &vp, c.get(
+	return vp, c.get(
 		"/validation_plan/"+validationPlanUUID.String(),
 		&vp,
 	)

--- a/pkg/conch/validations.go
+++ b/pkg/conch/validations.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Joyent, Inc.
+// Copyright Joyent, Inc.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pkg/conch/validations.go
+++ b/pkg/conch/validations.go
@@ -120,12 +120,12 @@ func (c *Conch) AddValidationToPlan(validationPlanUUID fmt.Stringer, validationU
 // RemoveValidationFromPlan removes a validation from a validation plan
 func (c *Conch) RemoveValidationFromPlan(validationPlanUUID fmt.Stringer, validationUUID fmt.Stringer) error {
 
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Delete("/validation_plan/"+validationPlanUUID.String()+"/validation/"+validationUUID.String()).
-		Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.httpDelete(
+		"/validation_plan/" +
+			validationPlanUUID.String() +
+			"/validation/" +
+			validationUUID.String(),
+	)
 }
 
 // GetValidationPlanValidations gets the list of validations associated with a validation plan

--- a/pkg/conch/validations.go
+++ b/pkg/conch/validations.go
@@ -91,13 +91,7 @@ func (c *Conch) CreateValidationPlan(newValidationPlan ValidationPlan) (Validati
 		newValidationPlan.Description,
 	}
 
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Post("/validation_plan").
-		BodyJSON(j).
-		Receive(&newValidationPlan, aerr)
-
-	return newValidationPlan, c.isHTTPResOk(res, err, aerr)
+	return newValidationPlan, c.post("/validation_plan", j, &newValidationPlan)
 }
 
 // AddValidationToPlan associates a validation with a validation plan
@@ -108,13 +102,11 @@ func (c *Conch) AddValidationToPlan(validationPlanUUID fmt.Stringer, validationU
 		validationUUID.String(),
 	}
 
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Post("/validation_plan/"+validationPlanUUID.String()+"/validation").
-		BodyJSON(j).
-		Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.post(
+		"/validation_plan/"+validationPlanUUID.String()+"/validation",
+		j,
+		nil,
+	)
 }
 
 // RemoveValidationFromPlan removes a validation from a validation plan
@@ -141,26 +133,21 @@ func (c *Conch) GetValidationPlanValidations(validationPlanUUID fmt.Stringer) ([
 func (c *Conch) RunDeviceValidation(deviceSerial string, validationUUID fmt.Stringer, body io.Reader) ([]ValidationResult, error) {
 	results := make([]ValidationResult, 0)
 
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Post("/device/"+deviceSerial+"/validation/"+validationUUID.String()).
-		Body(body).
-		Receive(&results, aerr)
-
-	return results, c.isHTTPResOk(res, err, aerr)
+	return results, c.post(
+		"/device/"+deviceSerial+"/validation/"+validationUUID.String(),
+		body,
+		&results,
+	)
 }
 
 // RunDeviceValidationPlan runs a validation plan against a given device and returns the results
 func (c *Conch) RunDeviceValidationPlan(deviceSerial string, validationPlanUUID fmt.Stringer, body io.Reader) ([]ValidationResult, error) {
 	results := make([]ValidationResult, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Post("/device/"+deviceSerial+"/validation_plan/"+validationPlanUUID.String()).
-		Body(body).
-		Receive(&results, aerr)
-
-	return results, c.isHTTPResOk(res, err, aerr)
+	return results, c.post(
+		"/device/"+deviceSerial+"/validation_plan/"+validationPlanUUID.String(),
+		body,
+		&results,
+	)
 }
 
 // DeviceValidationStates returns the stored validation states for a device

--- a/pkg/conch/validations_test.go
+++ b/pkg/conch/validations_test.go
@@ -20,7 +20,9 @@ func TestValidationErrors(t *testing.T) {
 	BuildAPI()
 	gock.Flush()
 
-	aerr := conch.APIError{ErrorMsg: "totally broken"}
+	aerr := struct {
+		ErrorMsg string `json:"error"`
+	}{"totally broken"}
 	aerrUnpacked := errors.New(aerr.ErrorMsg)
 
 	t.Run("GetValidations", func(t *testing.T) {

--- a/pkg/conch/validations_test.go
+++ b/pkg/conch/validations_test.go
@@ -49,7 +49,7 @@ func TestValidationErrors(t *testing.T) {
 		gock.New(API.BaseURL).Get(url).Reply(400).JSON(aerr)
 		ret, err := API.GetValidationPlan(id)
 		st.Expect(t, err, aerrUnpacked)
-		st.Expect(t, ret, &conch.ValidationPlan{})
+		st.Expect(t, ret, conch.ValidationPlan{})
 	})
 
 	t.Run("RunDeviceValidationPlan", func(t *testing.T) {

--- a/pkg/conch/workspaces.go
+++ b/pkg/conch/workspaces.go
@@ -104,13 +104,11 @@ func (c *Conch) CreateSubWorkspace(parent Workspace, sub Workspace) (Workspace, 
 		sub.Description,
 	}
 
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Post("/workspace/"+parent.ID.String()+"/child").
-		BodyJSON(j).
-		Receive(&sub, aerr)
-
-	return sub, c.isHTTPResOk(res, err, aerr)
+	return sub, c.post(
+		"/workspace/"+parent.ID.String()+"/child",
+		j,
+		&sub,
+	)
 }
 
 // AddRackToWorkspace adds an existing rack to an existing workspace, via
@@ -122,13 +120,7 @@ func (c *Conch) AddRackToWorkspace(workspaceUUID fmt.Stringer, rackUUID fmt.Stri
 		rackUUID.String(),
 	}
 
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Post("/workspace/"+workspaceUUID.String()+"/rack").
-		BodyJSON(j).
-		Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.post("/workspace/"+workspaceUUID.String()+"/rack", j, nil)
 }
 
 // DeleteRackFromWorkspace removes an existing rack from an existing workplace,
@@ -149,13 +141,7 @@ func (c *Conch) AddUserToWorkspace(workspaceUUID fmt.Stringer, user string, role
 		role,
 	}
 
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Post("/workspace/"+workspaceUUID.String()+"/user").
-		BodyJSON(body).
-		Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.post("/workspace/"+workspaceUUID.String()+"/user", body, nil)
 }
 
 // RemoveUserFromWorkspace ...

--- a/pkg/conch/workspaces.go
+++ b/pkg/conch/workspaces.go
@@ -134,12 +134,9 @@ func (c *Conch) AddRackToWorkspace(workspaceUUID fmt.Stringer, rackUUID fmt.Stri
 // DeleteRackFromWorkspace removes an existing rack from an existing workplace,
 // via /workspace/:uuid/rack/:uuid
 func (c *Conch) DeleteRackFromWorkspace(workspaceUUID fmt.Stringer, rackUUID fmt.Stringer) error {
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Delete("/workspace/"+workspaceUUID.String()+"/rack/"+rackUUID.String()).
-		Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.httpDelete(
+		"/workspace/" + workspaceUUID.String() + "/rack/" + rackUUID.String(),
+	)
 }
 
 // AddUserToWorkspace adds a user to a workspace via /workspace/:uuid/user
@@ -163,10 +160,5 @@ func (c *Conch) AddUserToWorkspace(workspaceUUID fmt.Stringer, user string, role
 
 // RemoveUserFromWorkspace ...
 func (c *Conch) RemoveUserFromWorkspace(workspaceUUID fmt.Stringer, email string) error {
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Delete("/workspace/"+workspaceUUID.String()+"/user/email="+email).
-		Receive(nil, aerr)
-
-	return c.isHTTPResOk(res, err, aerr)
+	return c.httpDelete("/workspace/" + workspaceUUID.String() + "/user/email=" + email)
 }

--- a/pkg/conch/workspaces.go
+++ b/pkg/conch/workspaces.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Joyent, Inc.
+// Copyright Joyent, Inc.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pkg/conch/workspaces.go
+++ b/pkg/conch/workspaces.go
@@ -45,63 +45,45 @@ type WorkspaceUser struct {
 // workspaces that the user has access to
 func (c *Conch) GetWorkspaces() ([]Workspace, error) {
 	workspaces := make([]Workspace, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().Get("/workspace").Receive(&workspaces, aerr)
-
-	return workspaces, c.isHTTPResOk(res, err, aerr)
+	return workspaces, c.get("/workspace", &workspaces)
 }
 
 // GetWorkspace returns the contents of /workspace/:uuid, getting information
 // about a single workspace
+// BUG(sungo): why is this returning a pointer
 func (c *Conch) GetWorkspace(workspaceUUID fmt.Stringer) (*Workspace, error) {
-	workspace := &Workspace{}
-
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Get("/workspace/"+workspaceUUID.String()).
-		Receive(&workspace, aerr)
-
-	return workspace, c.isHTTPResOk(res, err, aerr)
+	var workspace Workspace
+	return &workspace, c.get("/workspace/"+workspaceUUID.String(), &workspace)
 }
 
 // GetSubWorkspaces returns the contents of /workspace/:uuid/child, getting
 // a list of subworkspaces for the given workspace id
 func (c *Conch) GetSubWorkspaces(workspaceUUID fmt.Stringer) ([]Workspace, error) {
 	workspaces := make([]Workspace, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Get("/workspace/"+workspaceUUID.String()+"/child").
-		Receive(&workspaces, aerr)
-
-	return workspaces, c.isHTTPResOk(res, err, aerr)
+	return workspaces, c.get(
+		"/workspace/"+workspaceUUID.String()+"/child",
+		&workspaces,
+	)
 }
 
 // GetWorkspaceUsers returns the contents of /workspace/:uuid/users, getting
 // a list of users for the given workspace id
 func (c *Conch) GetWorkspaceUsers(workspaceUUID fmt.Stringer) ([]WorkspaceUser, error) {
 	users := make([]WorkspaceUser, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Get("/workspace/"+workspaceUUID.String()+"/user").
-		Receive(&users, aerr)
-
-	return users, c.isHTTPResOk(res, err, aerr)
+	return users, c.get(
+		"/workspace/"+workspaceUUID.String()+"/user",
+		&users,
+	)
 }
 
 // GetWorkspaceRooms returns the contents of /workspace/:uuid/room, getting
 // a list of rooms for the given workspace id
 func (c *Conch) GetWorkspaceRooms(workspaceUUID fmt.Stringer) ([]Room, error) {
 	rooms := make([]Room, 0)
-
-	aerr := &APIError{}
-	res, err := c.sling().New().
-		Get("/workspace/"+workspaceUUID.String()+"/room").
-		Receive(&rooms, aerr)
-
-	return rooms, c.isHTTPResOk(res, err, aerr)
+	return rooms, c.get(
+		"/workspace/"+workspaceUUID.String()+"/room",
+		&rooms,
+	)
 }
 
 // CreateSubWorkspace creates a sub workspace under the parent, via

--- a/pkg/conch/workspaces.go
+++ b/pkg/conch/workspaces.go
@@ -50,10 +50,8 @@ func (c *Conch) GetWorkspaces() ([]Workspace, error) {
 
 // GetWorkspace returns the contents of /workspace/:uuid, getting information
 // about a single workspace
-// BUG(sungo): why is this returning a pointer
-func (c *Conch) GetWorkspace(workspaceUUID fmt.Stringer) (*Workspace, error) {
-	var workspace Workspace
-	return &workspace, c.get("/workspace/"+workspaceUUID.String(), &workspace)
+func (c *Conch) GetWorkspace(workspaceUUID fmt.Stringer) (w Workspace, e error) {
+	return w, c.get("/workspace/"+workspaceUUID.String(), &w)
 }
 
 // GetSubWorkspaces returns the contents of /workspace/:uuid/child, getting

--- a/pkg/conch/workspaces_test.go
+++ b/pkg/conch/workspaces_test.go
@@ -19,7 +19,9 @@ func TestWorkspaceErrors(t *testing.T) {
 	BuildAPI()
 	gock.Flush()
 
-	aerr := conch.APIError{ErrorMsg: "totally broken"}
+	aerr := struct {
+		ErrorMsg string `json:"error"`
+	}{"totally broken"}
 	aerrUnpacked := errors.New(aerr.ErrorMsg)
 
 	t.Run("GetWorkspaces", func(t *testing.T) {

--- a/pkg/conch/workspaces_test.go
+++ b/pkg/conch/workspaces_test.go
@@ -38,7 +38,7 @@ func TestWorkspaceErrors(t *testing.T) {
 
 		ret, err := API.GetWorkspace(id)
 		st.Expect(t, err, aerrUnpacked)
-		st.Expect(t, ret, &conch.Workspace{})
+		st.Expect(t, ret, conch.Workspace{})
 	})
 
 	t.Run("GetSubWorkspaces", func(t *testing.T) {

--- a/pkg/config/main.go
+++ b/pkg/config/main.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Joyent, Inc.
+// Copyright Joyent, Inc.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
This gets sling out of the main codebase and isolates it. We're still using it to build http requests objects because, frankly, if I were to implement this myself it'd look just like sling. Otherwise, we're handling http requests on our own.

This lays the ground work for #125 and #155 