### PR TITLE
Import v2's notion of an extended device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ vendor
 
 .DS_Store
 
-bin/conch
-bin/conch-mbo
+bin
 
 release

--- a/pkg/conch/devices.go
+++ b/pkg/conch/devices.go
@@ -8,6 +8,7 @@ package conch
 
 import (
 	uuid "gopkg.in/satori/go.uuid.v1"
+	"sort"
 )
 
 // GetDevice returns a Device given a specific serial/id
@@ -15,6 +16,121 @@ func (c *Conch) GetDevice(serial string) (d Device, err error) {
 	d.ID = serial
 
 	return c.FillInDevice(d)
+}
+
+func (c *Conch) GetExtendedDevice(serial string) (ed ExtendedDevice, err error) {
+
+	d, err := c.GetDevice(serial)
+	if err != nil {
+		return ExtendedDevice{}, err
+	}
+
+	enclosures := make(map[string]map[int]Disk)
+	for _, disk := range d.Disks {
+		enclosure, ok := enclosures[disk.Enclosure]
+		if !ok {
+			enclosure = make(map[int]Disk)
+		}
+
+		if _, ok := enclosure[disk.Slot]; !ok {
+			enclosure[disk.Slot] = disk
+		}
+
+		enclosures[disk.Enclosure] = enclosure
+	}
+
+	/***********/
+
+	ed = ExtendedDevice{
+		Device:        d,
+		IPMI:          "",
+		HardwareName:  "",
+		SKU:           "",
+		Enclosures:    enclosures,
+		IsGraduated:   !d.Graduated.IsZero(),
+		IsTritonSetup: !d.TritonSetup.IsZero(),
+		IsValidated:   !d.Validated.IsZero(),
+		Validations:   make([]ValidationPlanExecution, 0),
+	}
+
+	allValidations := make(map[uuid.UUID]Validation)
+	serverValidations, err := c.GetValidations()
+	if err != nil {
+		return ed, err
+	}
+	for _, v := range serverValidations {
+		allValidations[v.ID] = v
+	}
+
+	if validationStates, err := c.DeviceValidationStates(d.ID); err == nil {
+
+		plans := make([]ValidationPlanExecution, 0)
+
+		for _, state := range validationStates {
+			name := "[unknown]"
+			validationPlan, err := c.GetValidationPlan(state.ValidationPlanID)
+			if err == nil {
+				name = validationPlan.Name
+			}
+
+			byValidationID := make(map[uuid.UUID][]ValidationResult)
+
+			for _, result := range state.Results {
+				results, ok := byValidationID[result.ValidationID]
+				if !ok {
+					results = make([]ValidationResult, 0)
+				}
+
+				results = append(results, result)
+				byValidationID[result.ValidationID] = results
+			}
+
+			runs := make(ValidationRuns, 0)
+			for id, results := range byValidationID {
+				var run ValidationRun
+				run.ID = id
+				run.Name = "[unknown]"
+				if v, ok := allValidations[id]; ok {
+					run.Name = v.Name
+				}
+				passed := true
+				for _, result := range results {
+					if result.Status != "pass" {
+						passed = false
+					}
+				}
+
+				run.Passed = passed
+				run.Results = results
+				runs = append(runs, run)
+			}
+
+			sort.Sort(runs)
+			plans = append(plans, ValidationPlanExecution{
+				ID:          state.ValidationPlanID,
+				Name:        name,
+				Validations: runs,
+			})
+
+		}
+
+		ed.Validations = plans
+	}
+
+	ipmi, err := c.GetDeviceIPMI(d.ID)
+	if err == nil {
+		ed.IPMI = ipmi
+	}
+
+	if !uuid.Equal(d.HardwareProduct, uuid.UUID{}) {
+		hp, err := c.GetHardwareProduct(d.HardwareProduct)
+		if err == nil {
+			ed.HardwareName = hp.Name
+			ed.SKU = hp.SKU
+		}
+	}
+
+	return ed, nil
 }
 
 // FillInDevice takes an existing device and fills in its data using "/device"

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -69,13 +69,13 @@ type Device struct {
 	Validated             pgtime.PgTime      `json:"validated"`
 	Validations           []ValidationReport `json:"validations"`
 	LatestReport          interface{}        `json:"latest_report"`
-	Disks                 []DeviceDisk       `json:"disks"`
 	LatestReportIsInvalid bool               `json:"latest_report_is_invalid"`
 	InvalidReport         string             `json:"invalid_report"`
+	Disks                 []Disk             `json:"disks"`
 }
 
 // DeviceDisk ...
-type DeviceDisk struct {
+type Disk struct {
 	ID           uuid.UUID     `json:"id"`
 	Created      pgtime.PgTime `json:"created"`
 	Updated      pgtime.PgTime `json:"updated"`

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -56,6 +56,7 @@ type Device struct {
 	Graduated             pgtime.PgTime      `json:"graduated"`
 	HardwareProduct       uuid.UUID          `json:"hardware_product"`
 	Health                string             `json:"health"`
+	Hostname              string             `json:"hostname"`
 	ID                    string             `json:"id"`
 	LastSeen              pgtime.PgTime      `json:"last_seen"`
 	Location              DeviceLocation     `json:"location"`
@@ -99,6 +100,18 @@ type DeviceLocation struct {
 	Datacenter            Datacenter            `json:"datacenter"`
 	Rack                  Rack                  `json:"rack"`
 	TargetHardwareProduct HardwareProductTarget `json:"target_hardware_product"`
+}
+
+type ExtendedDevice struct {
+	Device
+	IPMI          string                    `json:"ipmi"`
+	HardwareName  string                    `json:"hardware_name"`
+	SKU           string                    `json:"sku"`
+	Enclosures    map[string]map[int]Disk   `json:"enclosures"`
+	IsGraduated   bool                      `json:"is_graduated"`
+	IsTritonSetup bool                      `json:"is_triton_setup"`
+	IsValidated   bool                      `json:"is_validated"`
+	Validations   []ValidationPlanExecution `json:"validations"`
 }
 
 // GlobalDatacenter represents a datacenter in the global domain
@@ -321,6 +334,12 @@ type ValidationReport struct {
 	Status        int         `json:"status"` // Can use the ValidationReportStatus consts to understand status
 }
 
+type ValidationPlanExecution struct {
+	ID          uuid.UUID      `json:"id"`
+	Name        string         `json:"name"`
+	Validations ValidationRuns `json:"validations"`
+}
+
 // ValidationResult is a result of running a validation on a device
 type ValidationResult struct {
 	ID              uuid.UUID `json:"id"`
@@ -332,6 +351,27 @@ type ValidationResult struct {
 	Message         string    `json:"message"`
 	Status          string    `json:"status"`
 	ValidationID    uuid.UUID `json:"validation_id"`
+}
+
+type ValidationRun struct {
+	ID      uuid.UUID          `json:"id"`
+	Name    string             `json:"name"`
+	Passed  bool               `json:"passed"`
+	Results []ValidationResult `json:"results"`
+}
+
+type ValidationRuns []ValidationRun
+
+func (v ValidationRuns) Len() int {
+	return len(v)
+}
+
+func (v ValidationRuns) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
+func (v ValidationRuns) Less(i, j int) bool {
+	return v[i].Name < v[j].Name
 }
 
 // ValidationState is the result of running a validation plan on a device


### PR DESCRIPTION
ExtendedDevice and its getter let the user grab all kinds of info about the device that we don't provide elsewhere. I left it out of the regular struct and getter because this one is more complex than most, making many API calls. It also represents a significant data structure change and I want to wait until v2 to introduce that sort of breakage.