### PR TITLE
Fixes RunDeviceValidationPlan

### DIFF
--- a/pkg/commands/internal/validation/plan.go
+++ b/pkg/commands/internal/validation/plan.go
@@ -8,7 +8,8 @@
 package validation
 
 import (
-	"bufio"
+	"errors"
+	"io/ioutil"
 	"os"
 
 	"github.com/jawher/mow.cli"
@@ -86,9 +87,22 @@ func testValidationPlan(app *cli.Cmd) {
 	app.Spec = "DEVICE_ID"
 
 	app.Action = func() {
-		body := bufio.NewReader(os.Stdin)
+		bodyBytes, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		body := string(bodyBytes)
+		if len(body) <= 1 {
+			util.Bail(errors.New("no device report provided on stdin"))
+		}
+
 		var validationResults validationResults
-		validationResults, err := util.API.RunDeviceValidationPlan(*deviceSerial, validationPlanUUID, body)
+		validationResults, err = util.API.RunDeviceValidationPlan(
+			*deviceSerial,
+			validationPlanUUID,
+			body,
+		)
 		if err != nil {
 			util.Bail(err)
 		}

--- a/pkg/commands/internal/validation/validation.go
+++ b/pkg/commands/internal/validation/validation.go
@@ -8,7 +8,8 @@
 package validation
 
 import (
-	"bufio"
+	"errors"
+	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -69,10 +70,22 @@ func testValidation(app *cli.Cmd) {
 	app.Spec = "DEVICE_ID"
 
 	app.Action = func() {
-		body := bufio.NewReader(os.Stdin)
+		bodyBytes, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		body := string(bodyBytes)
+		if len(body) <= 1 {
+			util.Bail(errors.New("no device report provided on stdin"))
+		}
+
 		var validationResults validationResults
-		validationResults, err :=
-			util.API.RunDeviceValidation(*deviceSerial, validationUUID, body)
+		validationResults, err = util.API.RunDeviceValidation(
+			*deviceSerial,
+			validationUUID,
+			body,
+		)
 		if err != nil {
 			util.Bail(err)
 		}

--- a/pkg/conch/validations.go
+++ b/pkg/conch/validations.go
@@ -7,8 +7,8 @@
 package conch
 
 import (
+	"encoding/json"
 	"fmt"
-	"io"
 )
 
 // GetValidations returns the contents of /validation, getting the list of all
@@ -50,11 +50,10 @@ func (c *Conch) GetValidationPlanValidations(
 }
 
 // RunDeviceValidation runs a validation against given a device and returns the results
-// BUG(sungo): this is taking an io.Reader and trusting upstream to read it and close it. Knock that off.
 func (c *Conch) RunDeviceValidation(
 	deviceSerial string,
 	validationUUID fmt.Stringer,
-	body io.Reader,
+	body string,
 ) ([]ValidationResult, error) {
 
 	results := make([]ValidationResult, 0)
@@ -67,17 +66,23 @@ func (c *Conch) RunDeviceValidation(
 }
 
 // RunDeviceValidationPlan runs a validation plan against a given device and returns the results
-// BUG(sungo): this is taking an io.Reader and trusting upstream to read it and close it. Knock that off.
 func (c *Conch) RunDeviceValidationPlan(
 	deviceSerial string,
 	validationPlanUUID fmt.Stringer,
-	body io.Reader,
+	body string,
 ) ([]ValidationResult, error) {
 
 	results := make([]ValidationResult, 0)
+
+	var j interface{}
+	err := json.Unmarshal([]byte(body), &j)
+	if err != nil {
+		return results, err
+	}
+
 	return results, c.post(
 		"/device/"+deviceSerial+"/validation_plan/"+validationPlanUUID.String(),
-		body,
+		j,
 		&results,
 	)
 }

--- a/pkg/conch/validations_test.go
+++ b/pkg/conch/validations_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/nbio/st"
 	"gopkg.in/h2non/gock.v1"
 	uuid "gopkg.in/satori/go.uuid.v1"
-	"strings"
 	"testing"
 )
 
@@ -58,7 +57,7 @@ func TestValidationErrors(t *testing.T) {
 		url := "/device/" + dID + "/validation_plan/" + vpID.String()
 
 		gock.New(API.BaseURL).Post(url).Reply(400).JSON(aerr)
-		ret, err := API.RunDeviceValidationPlan(dID, vpID, strings.NewReader("{ }"))
+		ret, err := API.RunDeviceValidationPlan(dID, vpID, "{}")
 		st.Expect(t, err, aerrUnpacked)
 		st.Expect(t, ret, []conch.ValidationResult{})
 	})
@@ -69,7 +68,7 @@ func TestValidationErrors(t *testing.T) {
 		url := "/device/" + dID + "/validation/" + vpID.String()
 
 		gock.New(API.BaseURL).Post(url).Reply(400).JSON(aerr)
-		ret, err := API.RunDeviceValidation(dID, vpID, strings.NewReader("{ }"))
+		ret, err := API.RunDeviceValidation(dID, vpID, "{}")
 		st.Expect(t, err, aerrUnpacked)
 		st.Expect(t, ret, []conch.ValidationResult{})
 	})


### PR DESCRIPTION
... which I'm pretty sure could never have worked. Taking an io.Reader and passing it into sling might have worked if we were using `.Body()` instead of `.BodyJSON()`. As is, BodyJSON was trying to marshal an io.Reader struct into JSON which didn't work so well.

This does change the interface to RunDeviceValidationPlan which now takes a string instead of an io.Reader.

The various commands that call this function now explode if the user passes an empty string