### PR TITLE
Implement conch.GetVersion()

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -99,12 +99,12 @@
   revision = "fa5fdf94c78965f1aa8423f0cc50b8b8d728b05a"
 
 [[projects]]
-  digest = "1:bae937801c8147c4c64bd2e1b7d73292c89a55c904cb9fcded11e09f8c30a474"
+  digest = "1:f1e9221c1e17a438f8758d8da7be7ced1fc6132c4555d589d80f697d2cba7c8a"
   name = "gopkg.in/h2non/gock.v1"
   packages = ["."]
   pruneopts = "UT"
-  revision = "4692cba4394f79372bfe85996501ad43db9d82e0"
-  version = "v1.0.9"
+  revision = "a6029d17e101ac1594adafea9e63fd8c988a8701"
+  version = "v1.0.12"
 
 [[projects]]
   digest = "1:274f67cb6fed9588ea2521ecdac05a6d62a8c51c074c1fccc6a49a40ba80e925"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -63,7 +63,7 @@
 
 [[constraint]]
   name = "gopkg.in/h2non/gock.v1"
-  version = "1.0.8"
+  version = "1.0.12"
 
 
 [prune]

--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,19 @@ checksums: ## Build checksums for all release binaries
 	@rm -f release/*.sha256
 	@cd release && find . -type f -iname conch-\* -print0 | xargs -0 -n 1 -I {} sh -c 'shasum -a 256 {} > "{}.sha256"'
 
+.PHONY: staticcheck
+staticcheck: ## Run staticcheck
+	staticcheck ./...
 
 .PHONY: check
-check: ## Ensure that code matchs best practices and run tests
-	@echo "==> Checking for best practices"
-	staticcheck ./...
+check: staticcheck ## Ensure that code matchs best practices and run tests
 	@echo "==> Tests for pkg/conch"
 	@cd pkg/conch && go test -v 
+
+.PHONY: fasttest
+fasttest: staticcheck ## Run staticheck, also go test with -failfast
+	@echo "==> Tests for pkg/conch"
+	@cd pkg/conch && go test -failfast -v 
 
 tools: ## Download and install all dev/code tools
 	@echo "==> Installing dev tools"

--- a/pkg/conch/conch.go
+++ b/pkg/conch/conch.go
@@ -11,3 +11,17 @@ const (
 	// MinimumAPIVersion sets the earliest API version that we support.
 	MinimumAPIVersion = "2.22.0"
 )
+
+// GetVersion returns the API's version string, via /version
+func (c *Conch) GetVersion() (string, error) {
+	v := struct {
+		Version string `json:"version"`
+	}{}
+
+	err := c.get("/version", &v)
+	if err != nil {
+		return "", err
+	}
+
+	return v.Version, nil
+}

--- a/pkg/conch/errors.go
+++ b/pkg/conch/errors.go
@@ -35,10 +35,6 @@ var (
 	// filled out with enough data.
 	ErrBadInput = errors.New("incomplete data passed to the routine")
 
-	// ErrSemVerParse indicates that a semantic version string could not be
-	// parsed
-	ErrSemVerParse = errors.New("could not parse semantic version string")
-
 	// ErrNotSupported indicates that the API server does not support this
 	// command. This is typically determined via checks on conch.apiVersion
 	ErrNotSupported = errors.New("this function is not supported")

--- a/pkg/conch/sling.go
+++ b/pkg/conch/sling.go
@@ -16,10 +16,8 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
-	"strings"
 	"time"
 
-	"github.com/blang/semver"
 	"github.com/dghubble/sling"
 )
 
@@ -88,24 +86,6 @@ func (c *Conch) sling() *sling.Sling {
 		Client(c.HTTPClient).
 		Base(c.BaseURL).
 		Set("User-Agent", c.UA)
-
-	if c.apiVersion == nil {
-		sem, _ := semver.New(MinimumAPIVersion)
-		c.apiVersion = sem
-
-		body := struct {
-			Version string `json:"version"`
-		}{}
-
-		_, err := s.Get("/version").Receive(&body, nil)
-		if err != nil {
-			return s
-		}
-		apiVer, err := semver.New(strings.TrimLeft(body.Version, "v"))
-		if err == nil {
-			c.apiVersion = apiVer
-		}
-	}
 
 	u, _ := url.Parse(c.BaseURL)
 	if c.JWToken != "" {

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -11,7 +11,6 @@ import (
 	"net/http/cookiejar"
 	"time"
 
-	"github.com/blang/semver"
 	"github.com/joyent/conch-shell/pkg/pgtime"
 	uuid "gopkg.in/satori/go.uuid.v1"
 )
@@ -33,7 +32,6 @@ type Conch struct {
 
 	HTTPClient *http.Client
 	CookieJar  *cookiejar.Jar
-	apiVersion *semver.Version
 }
 
 // Datacenter represents a conch datacenter, aka an AZ


### PR DESCRIPTION
Important change: this doesn't affect anything user facing, but the lib will no longer grab `/version` during the first usage of `sling()`