### PR TITLE
add --debug and --trace modes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,5 @@ FROM scratch
 COPY --from=build /go/src/github.com/joyent/conch-shell/bin/conch /bin/conch
 COPY --from=build /etc/ssl /etc/ssl
 
-ENTRYPOINT [ "/bin/conch" ]
+ENTRYPOINT [ "/bin/conch", "--no-version-check" ]
 CMD ["version"]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,6 +26,14 @@
   version = "v3.5.1"
 
 [[projects]]
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = "UT"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
   digest = "1:ace1aef6acdf2c4647365dc87c14fb8b71ed8bb0b3ae114ffb216614a24da219"
   name = "github.com/dghubble/sling"
   packages = ["."]
@@ -121,6 +129,7 @@
     "github.com/Bowery/prompt",
     "github.com/DiSiqueira/GoTree",
     "github.com/blang/semver",
+    "github.com/davecgh/go-spew/spew",
     "github.com/dghubble/sling",
     "github.com/jawher/mow.cli",
     "github.com/mitchellh/go-homedir",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -65,6 +65,9 @@
   name = "gopkg.in/h2non/gock.v1"
   version = "1.0.12"
 
+[[constraint]]
+  name = "github.com/davecgh/go-spew"
+  version = "1.1.1"
 
 [prune]
   go-tests = true

--- a/cmd/conch/conch.go
+++ b/cmd/conch/conch.go
@@ -57,14 +57,20 @@ func main() {
 		configFile      = app.StringOpt("config c", "~/.conch.json", "Path to config file")
 		noVersion       = app.BoolOpt("no-version-check", false, "Skip Github version check")
 		profileOverride = app.StringOpt("profile p", "", "Override the active profile")
+		debugMode       = app.BoolOpt("debug", false, "Debug mode")
+		traceMode       = app.BoolOpt("trace", false, "Trace http requests. Warning: this is super loud")
 	)
 
 	app.Before = func() {
+		util.Debug = *debugMode
+		util.Trace = *traceMode
+
 		if *useJSON {
 			util.JSON = true
 		} else {
 			util.JSON = false
 		}
+
 		expandedPath, err := homedir.Expand(*configFile)
 		if err != nil {
 			util.Bail(err)

--- a/pkg/conch/debug.go
+++ b/pkg/conch/debug.go
@@ -1,0 +1,47 @@
+// Copyright Joyent, Inc.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package conch
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// ddp pretty prints a structure to stderr. "Deep Data Printer"
+func (c *Conch) ddp(v interface{}) {
+	spew.Fdump(
+		os.Stderr,
+		v,
+	)
+}
+
+// debugLog prints a string to stderr *if* the Debug flag is set
+func (c *Conch) debugLog(out string) {
+	if c.Debug {
+		fmt.Fprintln(os.Stderr, out)
+	}
+}
+
+// debugLogDDP is a convenience function for printing a data structure with a
+// message, *if* the Debug flag is set
+//lint:ignore U1000 sure this will get used later
+func (c *Conch) debugLogDDP(out string, v interface{}) {
+	if c.Debug {
+		c.debugLog(out)
+		c.ddp(v)
+	}
+}
+
+func init() {
+	spew.Config = spew.ConfigState{
+		Indent:                  "    ",
+		SortKeys:                true,
+		DisablePointerAddresses: true,
+	}
+}

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -29,6 +29,8 @@ type Conch struct {
 	UA      string
 	JWToken string
 	Expires int // This will be overwritten by JWT claims
+	Debug   bool
+	Trace   bool
 
 	HTTPClient *http.Client
 	CookieJar  *cookiejar.Jar

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -41,6 +41,14 @@ var (
 
 	// API is a global Conch API object
 	API *conch.Conch
+
+	// Debug decides if we should put the API in debug mode
+	// Yes, this is a bit of a kludge
+	Debug bool
+
+	// Trace decides if we should trace the HTTP transactions
+	// Yes, this is a bit of a kludge
+	Trace bool
 )
 
 // These variables are provided by the build environment
@@ -107,6 +115,8 @@ func BuildAPI() {
 		BaseURL: ActiveProfile.BaseURL,
 		Session: ActiveProfile.Session,
 		JWToken: ActiveProfile.JWToken,
+		Debug:   Debug,
+		Trace:   Trace,
 	}
 	if UserAgent != "" {
 		API.UA = UserAgent


### PR DESCRIPTION
 Fixes #125. Adds a new dependency

Won't provide an example of trace mode since a single request outputs 9000 log lines. Can provide an example on request out-of-band.

Example from debug mode:
```
» bin/conch --debug prof relogin
Password:
Request: POST http://[HOST]/login
  Request Body: {"user":"[USER]","password":"[PASS]"}

Response: HTTP 200 - {"jwt_token":"[TOKEN]"}
```