### PR TITLE
Repair the remaining Conch API v2.22 regressions

### DIFF
--- a/pkg/conch/hardware.go
+++ b/pkg/conch/hardware.go
@@ -83,6 +83,10 @@ func (c *Conch) GetHardwareVendor(name string) (v HardwareVendor, err error) {
 	return v, c.get("/hardware_vendor/"+name, &v)
 }
 
+func (c *Conch) GetHardwareVendorByID(id fmt.Stringer) (v HardwareVendor, err error) {
+	return v, c.get("/hardware_vendor/"+id.String(), &v)
+}
+
 // GetHardwareVendors ...
 func (c *Conch) GetHardwareVendors() ([]HardwareVendor, error) {
 	vendors := make([]HardwareVendor, 0)


### PR DESCRIPTION
This fixes #204,  the regression in vendor name display caused by an API regression.

It also adds the ability to look up hardware vendors by ID, a new feature added to the API in joyent/conch#597

This should be the last of the regression fixes against Conch API v2.22, paving the way for a 1.8 release.