### PR TITLE
Stop sending IDs when updating structures

### DIFF
--- a/pkg/conch/global_datacenter.go
+++ b/pkg/conch/global_datacenter.go
@@ -35,25 +35,16 @@ func (c *Conch) SaveGlobalDatacenter(d *GlobalDatacenter) error {
 	if d.Location == "" {
 		return ErrBadInput
 	}
+	j := struct {
+		Vendor     string `json:"vendor"`
+		Region     string `json:"region"`
+		Location   string `json:"location"`
+		VendorName string `json:"vendor_name,omitempty"`
+	}{d.Vendor, d.Region, d.Location, d.VendorName}
 
 	if uuid.Equal(d.ID, uuid.UUID{}) {
-		j := struct {
-			Vendor     string `json:"vendor"`
-			Region     string `json:"region"`
-			Location   string `json:"location"`
-			VendorName string `json:"vendor_name,omitempty"`
-		}{d.Vendor, d.Region, d.Location, d.VendorName}
-
 		return c.post("/dc", j, &d)
 	} else {
-		j := struct {
-			ID         string `json:"id"` // BUG(sungo): this is probably wrong
-			Vendor     string `json:"vendor,omitempty"`
-			Region     string `json:"region,omitempty"`
-			Location   string `json:"location,omitempty"`
-			VendorName string `json:"vendor_name,omitempty"`
-		}{d.ID.String(), d.Vendor, d.Region, d.Location, d.VendorName}
-
 		return c.post("/dc/"+d.ID.String(), j, &d)
 	}
 }

--- a/pkg/conch/global_datacenter_rack.go
+++ b/pkg/conch/global_datacenter_rack.go
@@ -36,37 +36,23 @@ func (c *Conch) SaveGlobalRack(r *GlobalRack) error {
 		return ErrBadInput
 	}
 
+	j := struct {
+		DatacenterRoomID string `json:"datacenter_room_id"`
+		Name             string `json:"name"`
+		RoleID           string `json:"role"`
+		SerialNumber     string `json:"serial_number,omitempty"`
+		AssetTag         string `json:"asset_tag,omitempty"`
+	}{
+		r.DatacenterRoomID.String(),
+		r.Name,
+		r.RoleID.String(),
+		r.SerialNumber,
+		r.AssetTag,
+	}
+
 	if uuid.Equal(r.ID, uuid.UUID{}) {
-
-		j := struct {
-			DatacenterRoomID string `json:"datacenter_room_id"`
-			Name             string `json:"name"`
-			RoleID           string `json:"role"`
-			SerialNumber     string `json:"serial_number,omitempty"`
-			AssetTag         string `json:"asset_tag,omitempty"`
-		}{
-			r.DatacenterRoomID.String(),
-			r.Name,
-			r.RoleID.String(),
-			r.SerialNumber,
-			r.AssetTag,
-		}
-
 		return c.post("/rack", j, &r)
 	} else {
-		j := struct {
-			DatacenterRoomID string `json:"datacenter_room_id"`
-			Name             string `json:"name"`
-			RoleID           string `json:"role"`
-			SerialNumber     string `json:"serial_number,omitempty"`
-			AssetTag         string `json:"asset_tag,omitempty"`
-		}{
-			r.DatacenterRoomID.String(),
-			r.Name,
-			r.RoleID.String(),
-			r.SerialNumber,
-			r.AssetTag,
-		}
 		return c.post("/rack/"+r.ID.String(), j, &r)
 	}
 

--- a/pkg/conch/global_datacenter_rack_role.go
+++ b/pkg/conch/global_datacenter_rack_role.go
@@ -34,32 +34,18 @@ func (c *Conch) SaveGlobalRackRole(r *GlobalRackRole) error {
 		return ErrBadInput
 	}
 
-	if uuid.Equal(r.ID, uuid.UUID{}) {
-		j := struct {
-			Name     string `json:"name"`
-			RackSize int    `json:"rack_size"`
-		}{
-			r.Name,
-			r.RackSize,
-		}
+	j := struct {
+		Name     string `json:"name"`
+		RackSize int    `json:"rack_size"`
+	}{
+		r.Name,
+		r.RackSize,
+	}
 
+	if uuid.Equal(r.ID, uuid.UUID{}) {
 		return c.post("/rack_role", j, &r)
 	} else {
-		j := struct {
-			ID       string `json:"id"` // BUG(sungo): this is probably wrong
-			Name     string `json:"name"`
-			RackSize int    `json:"rack_size"`
-		}{
-			r.ID.String(),
-			r.Name,
-			r.RackSize,
-		}
-
-		return c.post(
-			"/rack_role/"+r.ID.String(),
-			j,
-			&r,
-		)
+		return c.post("/rack_role/"+r.ID.String(), j, &r)
 	}
 
 }

--- a/pkg/conch/global_datacenter_room.go
+++ b/pkg/conch/global_datacenter_room.go
@@ -33,24 +33,16 @@ func (c *Conch) SaveGlobalRoom(r *GlobalRoom) error {
 		return ErrBadInput
 	}
 
-	if uuid.Equal(r.ID, uuid.UUID{}) {
-		j := struct {
-			Datacenter string `json:"datacenter"`
-			AZ         string `json:"az"`
-			Alias      string `json:"alias,omitempty"`
-			VendorName string `json:"vendor_name,omitempty"`
-		}{r.DatacenterID.String(), r.AZ, r.Alias, r.VendorName}
+	j := struct {
+		Datacenter string `json:"datacenter"`
+		AZ         string `json:"az"`
+		Alias      string `json:"alias,omitempty"`
+		VendorName string `json:"vendor_name,omitempty"`
+	}{r.DatacenterID.String(), r.AZ, r.Alias, r.VendorName}
 
+	if uuid.Equal(r.ID, uuid.UUID{}) {
 		return c.post("/room", j, &r)
 	} else {
-		j := struct {
-			ID         string `json:"id"` // BUG(sungo): this is probably wrong
-			Datacenter string `json:"datacenter"`
-			AZ         string `json:"az"`
-			Alias      string `json:"alias,omitempty"`
-			VendorName string `json:"vendor_name,omitempty"`
-		}{r.ID.String(), r.DatacenterID.String(), r.AZ, r.Alias, r.VendorName}
-
 		return c.post("/room/"+r.ID.String(), j, &r)
 	}
 }

--- a/pkg/conch/hardware.go
+++ b/pkg/conch/hardware.go
@@ -65,10 +65,7 @@ func (c *Conch) SaveHardwareProduct(h *HardwareProduct) error {
 		return c.post("/hardware_product", out, &h)
 	} else {
 		return c.post(
-			"/hardware_product/"+h.ID.String(),
-			out,
-			&h,
-		)
+			"/hardware_product/"+h.ID.String(), out, &h)
 	}
 }
 


### PR DESCRIPTION
In most of the "save" functions, where a thingy can be created or updated, updates attempted to send the ID which is incorrect and always has been. Fixes #199

In the "global" context, restores the ability to update datacenters, racks, rack roles, and rooms.