### PR TITLE
the release process now checks out from git, rather than using the local files.

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -10,14 +10,12 @@ ENV PATH "/go/bin:${PATH}"
 RUN go get honnef.co/go/tools/cmd/staticcheck
 
 RUN mkdir -p /go/src/github.com/joyent/conch-shell/
-WORKDIR /go/src/github.com/joyent/conch-shell/
 
-ARG VCS_REF="master"
-ARG VERSION="v0.0.0-dirty"
-LABEL org.label-schema.vcs-ref $VCS_REF
-LABEL org.label-schema.version $VERSION 
+ARG BRANCH="master"
 
-COPY . /go/src/github.com/joyent/conch-shell/
+WORKDIR /go/src/github.com/joyent/
+RUN git clone --branch $BRANCH https://github.com/joyent/conch-shell conch-shell
+WORKDIR /go/src/github.com/joyent/conch-shell
 
 ENTRYPOINT ["make" ]
 CMD [ "release", "checksums" ]

--- a/docker/release.bash
+++ b/docker/release.bash
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+PWD=$(pwd)
+
 PREFIX="joyentbuildops"
 NAME="conch-shell"
+
 : ${BUILDNUMBER:=0}
 
 : ${BUILDER:=${USER}}
@@ -10,16 +13,18 @@ BUILDER=$(echo "${BUILDER}" | sed 's/\//_/g' | sed 's/-/_/g')
 : ${LABEL:="latest"}
 LABEL=$(echo "${LABEL}" | sed 's/\//_/g')
 
+if test $LABEL == "master"; then
+	LABEL="latest"
+fi
+
+: ${BRANCH:="master"}
+
 IMAGE_NAME="${PREFIX}/${NAME}:${LABEL}"
 
-PWD=$(pwd)
-TAG=`git describe`
-HASH=`git rev-parse HEAD`
 
 docker build \
 	-t ${IMAGE_NAME} \
-	--build-arg VERSION=${TAG} \
-	--build-arg VCS_REF=${HASH} \
+	--build-arg BRANCH=${BRANCH} \
 	--file Dockerfile.release . \
 && \
 docker run --rm \


### PR DESCRIPTION
This gets us a clean environment, removes the -dirty problem, and enforces the notion that we are building releases from tags.

A change is required to the buildbot process to pass in a BRANCH variable instead of its current revision hash.