### PR TITLE
Drop cookie auth and improve error handling / reporting

### DIFF
--- a/pkg/conch/auth.go
+++ b/pkg/conch/auth.go
@@ -74,7 +74,7 @@ func (c *Conch) VerifyLogin(refreshTime int, forceJWT bool) error {
 	}
 
 	if jwtAuth.Token == "" {
-		return ErrLoginFailed
+		return ErrMalformedJWT
 	}
 
 	signature := ""
@@ -84,7 +84,7 @@ func (c *Conch) VerifyLogin(refreshTime int, forceJWT bool) error {
 		}
 	}
 	if signature == "" {
-		return ErrLoginFailed
+		return ErrMalformedJWT
 	}
 
 	jwt, err := c.ParseJWT(jwtAuth.Token, signature)
@@ -127,7 +127,7 @@ func (c *Conch) Login(user string, password string) error {
 		}
 	}
 	if signature == "" {
-		return ErrLoginFailed
+		return ErrMalformedJWT
 	}
 
 	jwt, err := c.ParseJWT(jwtAuth.Token, signature)
@@ -172,6 +172,10 @@ func (c *Conch) ParseJWT(token string, signature string) (ConchJWT, error) {
 	jwt.Token = token
 	jwt.Signature = signature
 
+	if c.Trace {
+		c.ddp(jwt)
+	}
+
 	bits := strings.Split(token, ".")
 	if len(bits) != 2 {
 		return jwt, ErrMalformedJWT
@@ -179,7 +183,7 @@ func (c *Conch) ParseJWT(token string, signature string) (ConchJWT, error) {
 
 	jwt.Header, err = decodeJWTsegment(bits[0])
 	if err != nil {
-		return jwt, err
+		return jwt, ErrMalformedJWT
 	}
 
 	jwt.Claims, err = decodeJWTsegment(bits[1])

--- a/pkg/conch/auth.go
+++ b/pkg/conch/auth.go
@@ -32,17 +32,14 @@ func (c *Conch) RevokeUserTokens(user string) error {
 }
 
 // RevokeOwnTokens revokes all auth tokens for the current user. Login() is
-// required after to generate new tokens. Clears the Session, JWToken, and
+// required after to generate new tokens. Clears the JWT, and
 // Expires attributes
 func (c *Conch) RevokeOwnTokens() error {
 	if err := c.post("/user/me/revoke", nil, nil); err != nil {
 		return err
 	}
 
-	c.Session = ""
-	c.JWToken = ""
-	c.Expires = 0
-
+	c.JWT = ConchJWT{}
 	return nil
 }
 
@@ -56,20 +53,13 @@ func (c *Conch) RevokeOwnTokens() error {
 // If the second parameter is true, a JWT refresh is forced, regardless of any
 // other parameters.
 //
-// NOTE: If the Conch struct contains cookie session data, it will be
-// automatically upgraded to JWT and the Session data will no longer function
 func (c *Conch) VerifyLogin(refreshTime int, forceJWT bool) error {
 	u, _ := url.Parse(c.BaseURL)
-	if c.JWToken != "" {
-		if err := c.recordJWTExpiry(); err != nil {
-			return ErrLoginFailed
-		}
-	}
 
 	if !forceJWT {
-		if refreshTime > 0 {
-			now := int(time.Now().Unix())
-			if c.Expires-now > refreshTime {
+		if (refreshTime > 0) && !c.JWT.Expires.IsZero() {
+			now := time.Now()
+			if now.Sub(c.JWT.Expires).Seconds() > float64(refreshTime) {
 				return nil
 			}
 		}
@@ -97,19 +87,21 @@ func (c *Conch) VerifyLogin(refreshTime int, forceJWT bool) error {
 		return ErrLoginFailed
 	}
 
-	c.JWToken = jwtAuth.Token + "." + signature
-	if err := c.recordJWTExpiry(); err != nil {
-		return ErrLoginFailed
+	jwt, err := c.ParseJWT(jwtAuth.Token, signature)
+	if err != nil {
+		return err
 	}
 
-	c.Session = ""
+	c.JWT = jwt
+
 	return nil
 }
 
 // Login uses the User, as listed in the Conch struct, and the provided
-// password to log into the Conch API and populate the Session entry in the
+// password to log into the Conch API and populate the JWT entry in the
 // Conch struct
 func (c *Conch) Login(user string, password string) error {
+	u, _ := url.Parse(c.BaseURL)
 
 	payload := struct {
 		User     string `json:"user"`
@@ -128,36 +120,22 @@ func (c *Conch) Login(user string, password string) error {
 		return err
 	}
 
-	u, _ := url.Parse(c.BaseURL)
-
-	if jwtAuth.Token != "" {
-		signature := ""
-		for _, cookie := range c.HTTPClient.Jar.Cookies(u) {
-			if cookie.Name == "jwt_sig" {
-				signature = cookie.Value
-			}
-		}
-		if signature == "" {
-			return ErrLoginFailed
-		}
-
-		c.JWToken = jwtAuth.Token + "." + signature
-
-		if err := c.recordJWTExpiry(); err != nil {
-			return ErrLoginFailed
-		}
-
-	} else {
-		for _, cookie := range c.HTTPClient.Jar.Cookies(u) {
-			if cookie.Name == "conch" {
-				c.Session = cookie.Value
-			}
-		}
-
-		if c.Session == "" {
-			return ErrLoginFailed
+	signature := ""
+	for _, cookie := range c.HTTPClient.Jar.Cookies(u) {
+		if cookie.Name == "jwt_sig" {
+			signature = cookie.Value
 		}
 	}
+	if signature == "" {
+		return ErrLoginFailed
+	}
+
+	jwt, err := c.ParseJWT(jwtAuth.Token, signature)
+	if err != nil {
+		return err
+	}
+
+	c.JWT = jwt
 
 	location, err := res.Location()
 
@@ -174,6 +152,52 @@ func (c *Conch) Login(user string, password string) error {
 	return nil
 }
 
+func decodeJWTsegment(seg string) (map[string]interface{}, error) {
+	var payload map[string]interface{}
+
+	b, err := base64.RawURLEncoding.DecodeString(seg)
+	if err != nil {
+		return payload, err
+	}
+
+	err = json.Unmarshal(b, &payload)
+
+	return payload, err
+}
+
+func (c *Conch) ParseJWT(token string, signature string) (ConchJWT, error) {
+	var jwt ConchJWT
+	var err error
+
+	jwt.Token = token
+	jwt.Signature = signature
+
+	bits := strings.Split(token, ".")
+	if len(bits) != 2 {
+		return jwt, ErrMalformedJWT
+	}
+
+	jwt.Header, err = decodeJWTsegment(bits[0])
+	if err != nil {
+		return jwt, err
+	}
+
+	jwt.Claims, err = decodeJWTsegment(bits[1])
+	if err != nil {
+		return jwt, err
+	}
+
+	if c.Trace {
+		c.ddp(jwt)
+	}
+
+	if val, ok := jwt.Claims["exp"]; ok {
+		jwt.Expires = time.Unix(int64(val.(float64)), 0)
+	}
+
+	return jwt, nil
+}
+
 // ChangePassword changes the password for the currently active profile
 func (c *Conch) ChangePassword(password string) error {
 	b := struct {
@@ -182,28 +206,4 @@ func (c *Conch) ChangePassword(password string) error {
 
 	return c.post("/user/me/password", b, nil)
 
-}
-
-func (c *Conch) recordJWTExpiry() error {
-	bits := strings.Split(c.JWToken, ".")
-	if len(bits) != 3 {
-		return ErrLoginFailed
-	}
-
-	b, err := base64.RawURLEncoding.DecodeString(bits[1])
-	if err != nil {
-		return err
-	}
-
-	jp := struct {
-		Exp int `json:"exp"`
-	}{}
-
-	err = json.Unmarshal(b, &jp)
-	if err != nil {
-		return err
-	}
-	c.Expires = jp.Exp
-
-	return nil
 }

--- a/pkg/conch/errors.go
+++ b/pkg/conch/errors.go
@@ -28,7 +28,7 @@ var (
 	// ErrBadInput indicates that the user passed incomplete or bad data to a
 	// routine. This typicallly only occurs when a struct parameter isn't
 	// filled out with enough data.
-	ErrBadInput = errors.New("internal error. incomplete data passed to the routine")
+	ErrBadInput = errors.New("incomplete data passed to the routine")
 
 	// ErrNotSupported indicates that the API server does not support this
 	// command. This is typically determined via checks on conch.apiVersion

--- a/pkg/conch/errors.go
+++ b/pkg/conch/errors.go
@@ -15,11 +15,6 @@ var (
 	// reasons
 	ErrLoginFailed = errors.New("login failed")
 
-	// ErrNoSessionData indicates that an auth related error occurred where
-	// either the user did not provide session data or no data was returned
-	// from the API
-	ErrNoSessionData = errors.New("no session data provided")
-
 	// ErrHTTPNotOk indicates that the API returned a non-200 status code that
 	// we don't know how to handle
 	ErrHTTPNotOk = errors.New("non-200 HTTP status code returned")
@@ -49,4 +44,6 @@ var (
 	// password before proceeding. Typically, the existing auth credentials
 	// will continue to work for a few minutes.
 	ErrMustChangePassword = errors.New("password must be changed")
+
+	ErrMalformedJWT = errors.New("JWT is malformed")
 )

--- a/pkg/conch/errors.go
+++ b/pkg/conch/errors.go
@@ -35,7 +35,7 @@ var (
 	ErrNotSupported = errors.New("this function is not supported")
 
 	// ErrNotAuthorized indicates that the API server returned a 401
-	ErrNotAuthorized = errors.New("not authorized for this endpoint")
+	ErrNotAuthorized = errors.New("invalid or expired auth credentials")
 
 	// ErrForbidden indicates that the API server returned a 403
 	ErrForbidden = errors.New("access to this endpoint is forbidden")

--- a/pkg/conch/errors.go
+++ b/pkg/conch/errors.go
@@ -23,12 +23,12 @@ var (
 	// inidicating that the requested data does not exist or is not available.
 	// NOTE: The API will also return this error if the user is not allowed to
 	// access the data in question.
-	ErrDataNotFound = errors.New("API could not find the data requested")
+	ErrDataNotFound = errors.New("server could not find the data requested")
 
 	// ErrBadInput indicates that the user passed incomplete or bad data to a
 	// routine. This typicallly only occurs when a struct parameter isn't
 	// filled out with enough data.
-	ErrBadInput = errors.New("incomplete data passed to the routine")
+	ErrBadInput = errors.New("internal error. incomplete data passed to the routine")
 
 	// ErrNotSupported indicates that the API server does not support this
 	// command. This is typically determined via checks on conch.apiVersion
@@ -38,12 +38,12 @@ var (
 	ErrNotAuthorized = errors.New("invalid or expired auth credentials")
 
 	// ErrForbidden indicates that the API server returned a 403
-	ErrForbidden = errors.New("access to this endpoint is forbidden")
+	ErrForbidden = errors.New("access to this data is forbidden")
 
 	// ErrMustChangePassword is used to signal that the user must change their
 	// password before proceeding. Typically, the existing auth credentials
 	// will continue to work for a few minutes.
-	ErrMustChangePassword = errors.New("password must be changed")
+	ErrMustChangePassword = errors.New("user must change their password")
 
-	ErrMalformedJWT = errors.New("JWT is malformed")
+	ErrMalformedJWT = errors.New("server sent a malformed auth token")
 )

--- a/pkg/conch/sling.go
+++ b/pkg/conch/sling.go
@@ -15,7 +15,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/cookiejar"
-	"net/url"
 	"time"
 
 	"github.com/dghubble/sling"
@@ -87,24 +86,10 @@ func (c *Conch) sling() *sling.Sling {
 		Base(c.BaseURL).
 		Set("User-Agent", c.UA)
 
-	u, _ := url.Parse(c.BaseURL)
-	if c.JWToken != "" {
-		if c.Expires == 0 {
-			_ = c.recordJWTExpiry
-		}
-
-		s = s.Set("Authorization", "Bearer "+c.JWToken)
-
-	} else if c.Session != "" {
-
-		cookie := &http.Cookie{
-			Name:  "conch",
-			Value: c.Session,
-		}
-		c.CookieJar.SetCookies(
-			u,
-			[]*http.Cookie{cookie},
-		)
+	// BUG(sungo) This is mostly for the config back compat code. Once that's
+	// gone, we can probably just check the expires value
+	if (c.JWT.Token != "") && (c.JWT.Signature != "") {
+		s = s.Set("Authorization", "Bearer "+c.JWT.FullToken())
 	}
 
 	return s

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -24,16 +24,28 @@ const (
 
 // Conch contains auth and configuration data
 type Conch struct {
-	Session string // DEPRECATED
 	BaseURL string
 	UA      string
-	JWToken string
-	Expires int // This will be overwritten by JWT claims
 	Debug   bool
 	Trace   bool
+	JWT     ConchJWT
 
 	HTTPClient *http.Client
 	CookieJar  *cookiejar.Jar
+}
+
+type ConchJWT struct {
+	Expires time.Time
+
+	Header map[string]interface{}
+	Claims map[string]interface{}
+
+	Token     string
+	Signature string
+}
+
+func (j *ConchJWT) FullToken() string {
+	return j.Token + "." + j.Signature
 }
 
 // Datacenter represents a conch datacenter, aka an AZ

--- a/pkg/config/main.go
+++ b/pkg/config/main.go
@@ -9,10 +9,16 @@
 package config
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
-	uuid "gopkg.in/satori/go.uuid.v1"
+	"fmt"
 	"io/ioutil"
+	"strings"
+	"time"
+
+	"github.com/joyent/conch-shell/pkg/conch"
+	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 // ErrConfigNoPath is issued when a file operation is attempted on a
@@ -29,16 +35,16 @@ type ConchConfig struct {
 // ConchProfile is an individual environment, consisting of login data, API
 // settings, and an optional default workspace
 type ConchProfile struct {
-	Name             string    `json:"name"`
-	User             string    `json:"user"`
-	Session          string    `json:"session,omitempty"`
-	WorkspaceUUID    uuid.UUID `json:"workspace_id"`
-	WorkspaceName    string    `json:"workspace_name"`
-	BaseURL          string    `json:"api_url"`
-	Active           bool      `json:"active"`
-	JWToken          string    `json:"jwt,omitempty"`
-	Expires          int       `json:"expires,omitempty"`
-	SkipVersionCheck bool      `json:"skip_version_check"`
+	Name             string         `json:"name"`
+	User             string         `json:"user"`
+	Session          string         `json:"session,omitempty"`
+	WorkspaceUUID    uuid.UUID      `json:"workspace_id"`
+	WorkspaceName    string         `json:"workspace_name"`
+	BaseURL          string         `json:"api_url"`
+	Active           bool           `json:"active"`
+	JWT              conch.ConchJWT `json:"jwt"`
+	Expires          time.Time      `json:"expires,omitempty"`
+	SkipVersionCheck bool           `json:"skip_version_check"`
 }
 
 // New provides an initialized struct with default values geared towards a
@@ -55,15 +61,73 @@ func New() (c *ConchConfig) {
 
 // NewFromJSON unmarshals a JSON blob into a ConchConfig struct
 func NewFromJSON(j string) (c *ConchConfig, err error) {
-	c = New()
 
-	err = json.Unmarshal([]byte(j), c)
-	if err != nil {
-		return c, err
+	// BUG(sungo): This transition code is a mess but necessary for
+	// compatbility. Need to give it a release or two in production before
+	// removing this grossness.
+	type conchProfileTransition struct {
+		Name             string    `json:"name"`
+		User             string    `json:"user"`
+		Session          string    `json:"session,omitempty"`
+		WorkspaceUUID    uuid.UUID `json:"workspace_id"`
+		WorkspaceName    string    `json:"workspace_name"`
+		BaseURL          string    `json:"api_url"`
+		Active           bool      `json:"active"`
+		JWT              string    `json:"jwt"`
+		Expires          int64     `json:"expires,omitempty"`
+		SkipVersionCheck bool      `json:"skip_version_check"`
 	}
 
-	if c.Profiles == nil {
-		c.Profiles = make(map[string]*ConchProfile)
+	type conchConfigTransition struct {
+		Path     string                             `json:"path"`
+		Profiles map[string]*conchProfileTransition `json:"profiles"`
+	}
+
+	ct := &conchConfigTransition{
+		Path:     "~/.conch.json",
+		Profiles: make(map[string]*conchProfileTransition),
+	}
+
+	c = New()
+	err = json.Unmarshal([]byte(j), ct)
+
+	if err != nil {
+		err = json.Unmarshal([]byte(j), c)
+		if err != nil {
+			return c, err
+		}
+
+		if c.Profiles == nil {
+			c.Profiles = make(map[string]*ConchProfile)
+		}
+
+	} else {
+		for _, p := range ct.Profiles {
+
+			jwt := conch.ConchJWT{}
+
+			bits := strings.Split(p.JWT, ".")
+			fmt.Println(bits)
+			if len(bits) == 3 {
+				token := bits[0] + "." + bits[1]
+				sig := bits[2]
+				jwt, _ = parseJWT(token, sig)
+			}
+
+			pNew := &ConchProfile{
+				Name:             p.Name,
+				User:             p.User,
+				Session:          p.Session,
+				WorkspaceUUID:    p.WorkspaceUUID,
+				WorkspaceName:    p.WorkspaceName,
+				BaseURL:          p.BaseURL,
+				Active:           p.Active,
+				JWT:              jwt,
+				Expires:          time.Unix(p.Expires, 0),
+				SkipVersionCheck: p.SkipVersionCheck,
+			}
+			c.Profiles[pNew.Name] = pNew
+		}
 	}
 
 	return c, nil
@@ -108,4 +172,48 @@ func (c *ConchConfig) SerializeToFile(path string) (err error) {
 
 	err = ioutil.WriteFile(path, j, 0644)
 	return err
+}
+
+// BUG(sungo): entirely for config backcompat
+func decodeJWTsegment(seg string) (map[string]interface{}, error) {
+	var payload map[string]interface{}
+
+	b, err := base64.RawURLEncoding.DecodeString(seg)
+	if err != nil {
+		return payload, err
+	}
+
+	err = json.Unmarshal(b, &payload)
+
+	return payload, err
+}
+
+// BUG(sungo): entirely for config backcompat
+func parseJWT(token string, signature string) (conch.ConchJWT, error) {
+	var jwt conch.ConchJWT
+	var err error
+
+	jwt.Token = token
+	jwt.Signature = signature
+
+	bits := strings.Split(token, ".")
+	if len(bits) != 2 {
+		return jwt, conch.ErrMalformedJWT
+	}
+
+	jwt.Header, err = decodeJWTsegment(bits[0])
+	if err != nil {
+		return jwt, err
+	}
+
+	jwt.Claims, err = decodeJWTsegment(bits[1])
+	if err != nil {
+		return jwt, err
+	}
+
+	if val, ok := jwt.Claims["exp"]; ok {
+		jwt.Expires = time.Unix(int64(val.(float64)), 0)
+	}
+
+	return jwt, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -132,19 +132,39 @@ func GetMarkdownTable() (table *tablewriter.Table) {
 
 // Bail is a --json aware way of dying
 func Bail(err error) {
+	var msg string
+
+	switch err {
+	case conch.ErrBadInput:
+		msg = err.Error() + " -- Internal Error. Please file a GHI"
+
+	case conch.ErrNotAuthorized:
+		msg = err.Error() + " -- Running 'profile relogin' might resolve this"
+
+	case conch.ErrMalformedJWT:
+		msg = "The server sent a malformed auth token. Please contact the Conch team"
+
+	case conch.ErrLoginFailed:
+		msg = "Something unexpected happened during authentication. Please run with --debug and contact the Conch team"
+
+	default:
+		msg = err.Error()
+	}
+
 	if JSON {
 		j, _ := json.Marshal(struct {
 			Error   bool   `json:"error"`
 			Message string `json:"message"`
 		}{
 			true,
-			fmt.Sprintf("%v", err),
+			msg,
 		})
 
 		fmt.Println(string(j))
 	} else {
-		fmt.Println(err)
+		fmt.Println(msg)
 	}
+
 	cli.Exit(1)
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -92,9 +92,7 @@ func BuildAPIAndVerifyLogin() {
 	if err := API.VerifyLogin(RefreshTokenTime, false); err != nil {
 		Bail(err)
 	}
-	ActiveProfile.Session = API.Session
-	ActiveProfile.JWToken = API.JWToken
-	ActiveProfile.Expires = API.Expires
+	ActiveProfile.JWT = API.JWT
 	WriteConfig()
 }
 
@@ -113,8 +111,7 @@ func BuildAPI() {
 
 	API = &conch.Conch{
 		BaseURL: ActiveProfile.BaseURL,
-		Session: ActiveProfile.Session,
-		JWToken: ActiveProfile.JWToken,
+		JWT:     ActiveProfile.JWT,
 		Debug:   Debug,
 		Trace:   Trace,
 	}
@@ -385,8 +382,7 @@ func InteractiveForcePasswordChange() {
 		Bail(err)
 	}
 
-	ActiveProfile.Session = API.Session
-	ActiveProfile.JWToken = API.JWToken
+	ActiveProfile.JWT = API.JWT
 
 	WriteConfig()
 }


### PR DESCRIPTION
Closes #219 
Closes #132 

Along with some much needed improvement to user-facing error handing, this PR drops all support for cookie auth, and implements a full parser for JWT. The config file syntax has changed but existing configs should be upgraded silently when the user next uses the app. 