### PR TITLE
In the output of `device get` include the datacenter vendor and rack id

### DIFF
--- a/pkg/commands/internal/devices/devices.go
+++ b/pkg/commands/internal/devices/devices.go
@@ -26,7 +26,7 @@ Health: {{ .D.Health }}
 State:	{{ .D.State }}
 
 Location:
-  Datacenter: {{ .D.Location.Datacenter.Name }}
+  Datacenter: {{ .D.Location.Datacenter.VendorName }} / {{ .D.Location.Datacenter.Name }}
   Rack: {{ .D.Location.Rack.Name }} - RU {{ .D.Location.Rack.Unit }}
 {{ if .D.AssetTag }}
 Asset Tag: {{ .D.AssetTag }}

--- a/pkg/commands/internal/devices/devices.go
+++ b/pkg/commands/internal/devices/devices.go
@@ -28,6 +28,7 @@ State:	{{ .D.State }}
 Location:
   Datacenter: {{ .D.Location.Datacenter.VendorName }} / {{ .D.Location.Datacenter.Name }}
   Rack: {{ .D.Location.Rack.Name }} - RU {{ .D.Location.Rack.Unit }}
+    ID: {{ .D.Location.Rack.ID }}
 {{ if .D.AssetTag }}
 Asset Tag: {{ .D.AssetTag }}
 {{ end -}}


### PR DESCRIPTION
Closes #118 