### PR TITLE
When rendering a list of devices, remove the confusing FLAGS column and always display the validated and graudated timestamps

### DIFF
--- a/pkg/commands/internal/workspaces/workspaces.go
+++ b/pkg/commands/internal/workspaces/workspaces.go
@@ -181,18 +181,6 @@ func getDevices(app *cli.Cmd) {
 			return
 		}
 
-		if *fullOutput {
-			filledIn := make([]conch.Device, 0)
-			for _, d := range devices {
-				fullDevice, err := util.API.FillInDevice(d)
-				if err != nil {
-					util.Bail(err)
-				}
-				filledIn = append(filledIn, fullDevice)
-			}
-			devices = filledIn
-		}
-
 		if err := util.DisplayDevices(devices, *fullOutput); err != nil {
 			util.Bail(err)
 		}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -174,6 +174,19 @@ func Bail(err error) {
 func DisplayDevices(devices []conch.Device, fullOutput bool) (err error) {
 	minimals := make([]MinimalDevice, 0)
 	for _, d := range devices {
+		if fullOutput && d.Location.Rack.Name == "" {
+			// The table renderer only needs the location data so there's no
+			// need to go get a full DetailedDevice with its attendant database
+			// queries.
+			// In my experience, getting the full DetailedDevice doubles this
+			// query time [sungo]
+			loc, err := API.GetDeviceLocation(d.ID)
+			if err != nil {
+				Bail(err)
+			}
+			d.Location = loc
+		}
+
 		minimals = append(minimals, MinimalDevice{
 			d.ID,
 			d.AssetTag,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -75,14 +75,16 @@ func TimeStr(t time.Time) string {
 // MinimalDevice represents a limited subset of Device data, that which we are
 // going to present to the user
 type MinimalDevice struct {
-	ID       string        `json:"id"`
-	AssetTag string        `json:"asset_tag"`
-	Created  pgtime.PgTime `json:"created"`
-	LastSeen pgtime.PgTime `json:"last_seen"`
-	Health   string        `json:"health"`
-	Flags    string        `json:"flags"`
-	AZ       string        `json:"az"`
-	Rack     string        `json:"rack"`
+	ID        string        `json:"id"`
+	AssetTag  string        `json:"asset_tag"`
+	Created   pgtime.PgTime `json:"created"`
+	LastSeen  pgtime.PgTime `json:"last_seen"`
+	Health    string        `json:"health"`
+	Flags     string        `json:"flags"`
+	AZ        string        `json:"az"`
+	Rack      string        `json:"rack"`
+	Graduated pgtime.PgTime `json:"graduated"`
+	Validated pgtime.PgTime `json:"validated"`
 }
 
 // BuildAPIAndVerifyLogin builds a Conch object using the Config data and calls
@@ -182,6 +184,8 @@ func DisplayDevices(devices []conch.Device, fullOutput bool) (err error) {
 			GenerateDeviceFlags(d),
 			d.Location.Datacenter.Name,
 			d.Location.Rack.Name,
+			d.Validated,
+			d.Graduated,
 		})
 	}
 
@@ -216,7 +220,8 @@ func TableizeMinimalDevices(devices []MinimalDevice, fullOutput bool, table *tab
 			"Created",
 			"Last Seen",
 			"Health",
-			"Flags",
+			"Validated",
+			"Graduated",
 		})
 	} else {
 		table.SetHeader([]string{
@@ -236,6 +241,15 @@ func TableizeMinimalDevices(devices []MinimalDevice, fullOutput bool, table *tab
 		}
 
 		if fullOutput {
+			validated := ""
+			if !d.Validated.IsZero() {
+				validated = TimeStr(d.Validated.AsUTC())
+			}
+			graduated := ""
+			if !d.Graduated.IsZero() {
+				graduated = TimeStr(d.Graduated.AsUTC())
+			}
+
 			table.Append([]string{
 				d.AZ,
 				d.Rack,
@@ -244,7 +258,8 @@ func TableizeMinimalDevices(devices []MinimalDevice, fullOutput bool, table *tab
 				TimeStr(d.Created.AsUTC()),
 				lastSeen,
 				d.Health,
-				d.Flags,
+				validated,
+				graduated,
 			})
 		} else {
 			table.Append([]string{


### PR DESCRIPTION
This also starts to address the speed issue in this command. I'll file a separate GHI for the rest of that work.

Closes #143 
Closes #7 