### PR TITLE
SkipVersionCheck is now global

### DIFF
--- a/cmd/conch/conch.go
+++ b/cmd/conch/conch.go
@@ -99,10 +99,9 @@ func main() {
 		if *noVersion {
 			checkVersion = false
 		}
-		if util.ActiveProfile != nil {
-			if util.ActiveProfile.SkipVersionCheck {
-				checkVersion = false
-			}
+
+		if cfg.SkipVersionCheck {
+			checkVersion = false
 		}
 
 		if checkVersion {

--- a/pkg/commands/internal/profile/init.go
+++ b/pkg/commands/internal/profile/init.go
@@ -76,11 +76,23 @@ func Init(app *cli.Cli) {
 						"Change which profile is active",
 						setActive,
 					)
+				},
+			)
 
+			cmd.Command(
+				"global",
+				"Change global settings that apply regardless of the profile chosen",
+				func(cmd *cli.Cmd) {
 					cmd.Command(
 						"version-check vc",
 						"Enable/disable version checking",
 						func(cmd *cli.Cmd) {
+							cmd.Command(
+								"status",
+								"See if version checking is enabled or disabled",
+								statusVersionCheck,
+							)
+
 							cmd.Command(
 								"enable",
 								"Enable version checking",
@@ -96,7 +108,6 @@ func Init(app *cli.Cli) {
 					)
 				},
 			)
-
 		},
 	)
 }

--- a/pkg/commands/internal/profile/profile.go
+++ b/pkg/commands/internal/profile/profile.go
@@ -185,7 +185,6 @@ func listProfiles(app *cli.Cmd) {
 			"Workspace Name",
 			"API URL",
 			"Expires",
-			"Version Check",
 		})
 
 		for _, prof := range util.Config.Profiles {
@@ -203,10 +202,6 @@ func listProfiles(app *cli.Cmd) {
 			if !prof.JWT.Expires.IsZero() {
 				expires = util.TimeStr(prof.JWT.Expires)
 			}
-			versionCheck := "Y"
-			if prof.SkipVersionCheck {
-				versionCheck = "N"
-			}
 
 			table.Append([]string{
 				active,
@@ -215,7 +210,6 @@ func listProfiles(app *cli.Cmd) {
 				workspaceName,
 				prof.BaseURL,
 				expires,
-				versionCheck,
 			})
 		}
 		table.Render()
@@ -393,14 +387,24 @@ func changePassword(app *cli.Cmd) {
 
 func enableVersionCheck(app *cli.Cmd) {
 	app.Action = func() {
-		util.ActiveProfile.SkipVersionCheck = false
+		util.Config.SkipVersionCheck = false
 		util.WriteConfig()
 	}
 }
 
 func disableVersionCheck(app *cli.Cmd) {
 	app.Action = func() {
-		util.ActiveProfile.SkipVersionCheck = true
+		util.Config.SkipVersionCheck = true
 		util.WriteConfig()
+	}
+}
+
+func statusVersionCheck(app *cli.Cmd) {
+	app.Action = func() {
+		if util.Config.SkipVersionCheck {
+			fmt.Println("disabled")
+		} else {
+			fmt.Println("enabled")
+		}
 	}
 }

--- a/pkg/config/main.go
+++ b/pkg/config/main.go
@@ -37,7 +37,6 @@ type ConchConfig struct {
 type ConchProfile struct {
 	Name             string         `json:"name"`
 	User             string         `json:"user"`
-	Session          string         `json:"session,omitempty"`
 	WorkspaceUUID    uuid.UUID      `json:"workspace_id"`
 	WorkspaceName    string         `json:"workspace_name"`
 	BaseURL          string         `json:"api_url"`
@@ -117,7 +116,6 @@ func NewFromJSON(j string) (c *ConchConfig, err error) {
 			pNew := &ConchProfile{
 				Name:             p.Name,
 				User:             p.User,
-				Session:          p.Session,
 				WorkspaceUUID:    p.WorkspaceUUID,
 				WorkspaceName:    p.WorkspaceName,
 				BaseURL:          p.BaseURL,

--- a/pkg/config/main.go
+++ b/pkg/config/main.go
@@ -28,22 +28,22 @@ var ErrConfigNoPath = errors.New("no path found in config data")
 // ConchConfig represents the configuration information for the shell, mostly
 // just a profile list
 type ConchConfig struct {
-	Path     string                   `json:"path"`
-	Profiles map[string]*ConchProfile `json:"profiles"`
+	Path             string                   `json:"path"`
+	SkipVersionCheck bool                     `json:"skip_version_check"`
+	Profiles         map[string]*ConchProfile `json:"profiles"`
 }
 
 // ConchProfile is an individual environment, consisting of login data, API
 // settings, and an optional default workspace
 type ConchProfile struct {
-	Name             string         `json:"name"`
-	User             string         `json:"user"`
-	WorkspaceUUID    uuid.UUID      `json:"workspace_id"`
-	WorkspaceName    string         `json:"workspace_name"`
-	BaseURL          string         `json:"api_url"`
-	Active           bool           `json:"active"`
-	JWT              conch.ConchJWT `json:"jwt"`
-	Expires          time.Time      `json:"expires,omitempty"`
-	SkipVersionCheck bool           `json:"skip_version_check"`
+	Name          string         `json:"name"`
+	User          string         `json:"user"`
+	WorkspaceUUID uuid.UUID      `json:"workspace_id"`
+	WorkspaceName string         `json:"workspace_name"`
+	BaseURL       string         `json:"api_url"`
+	Active        bool           `json:"active"`
+	JWT           conch.ConchJWT `json:"jwt"`
+	Expires       time.Time      `json:"expires,omitempty"`
 }
 
 // New provides an initialized struct with default values geared towards a
@@ -51,8 +51,9 @@ type ConchProfile struct {
 // "http://localhost:5001".
 func New() (c *ConchConfig) {
 	c = &ConchConfig{
-		Path:     "~/.conch.json",
-		Profiles: make(map[string]*ConchProfile),
+		Path:             "~/.conch.json",
+		Profiles:         make(map[string]*ConchProfile),
+		SkipVersionCheck: false,
 	}
 
 	return c
@@ -114,15 +115,14 @@ func NewFromJSON(j string) (c *ConchConfig, err error) {
 			}
 
 			pNew := &ConchProfile{
-				Name:             p.Name,
-				User:             p.User,
-				WorkspaceUUID:    p.WorkspaceUUID,
-				WorkspaceName:    p.WorkspaceName,
-				BaseURL:          p.BaseURL,
-				Active:           p.Active,
-				JWT:              jwt,
-				Expires:          time.Unix(p.Expires, 0),
-				SkipVersionCheck: p.SkipVersionCheck,
+				Name:          p.Name,
+				User:          p.User,
+				WorkspaceUUID: p.WorkspaceUUID,
+				WorkspaceName: p.WorkspaceName,
+				BaseURL:       p.BaseURL,
+				Active:        p.Active,
+				JWT:           jwt,
+				Expires:       time.Unix(p.Expires, 0),
 			}
 			c.Profiles[pNew.Name] = pNew
 		}


### PR DESCRIPTION
Closes #222 

The breaking change happens in two places.

First, while the config transition code will update the configuration file, it does not change the default global value. If a user has SkipVersionCheck enabled on a profile and wishes to retain the setting, they will need to manually change the value after upgrading.

Second, the version check commands have moved from `profile get` to`profile global`.