### PR TITLE
allow the user to filter `ws :id devices` by the validated field

### DIFF
--- a/pkg/commands/internal/workspaces/health.go
+++ b/pkg/commands/internal/workspaces/health.go
@@ -51,6 +51,7 @@ func getHealth(app *cli.Cmd) {
 			true,
 			"",
 			"",
+			"",
 		)
 
 		if err != nil {

--- a/pkg/commands/internal/workspaces/workspaces.go
+++ b/pkg/commands/internal/workspaces/workspaces.go
@@ -153,6 +153,7 @@ func getDevices(app *cli.Cmd) {
 		idsOnly    = app.BoolOpt("ids-only", false, "Only retrieve device IDs")
 		graduated  = app.StringOpt("graduated", "", "Filter by the 'graduated' field")
 		health     = app.StringOpt("health", "", "Filter by the 'health' field")
+		validated  = app.StringOpt("validated", "", "Filter by the 'validated' field")
 	)
 
 	app.Action = func() {
@@ -161,6 +162,7 @@ func getDevices(app *cli.Cmd) {
 			*idsOnly,
 			*graduated,
 			*health,
+			*validated,
 		)
 		if err != nil {
 			util.Bail(err)

--- a/pkg/conch/conch.go
+++ b/pkg/conch/conch.go
@@ -9,7 +9,7 @@ package conch
 
 const (
 	// MinimumAPIVersion sets the earliest API version that we support.
-	MinimumAPIVersion = "2.23.0"
+	MinimumAPIVersion = "2.24.0"
 )
 
 // GetVersion returns the API's version string, via /version

--- a/pkg/conch/workspaces.go
+++ b/pkg/conch/workspaces.go
@@ -54,7 +54,13 @@ func (c *Conch) GetWorkspaceRack(
 // Pass true for 'IDsOnly' to get Devices with only the ID field populated
 // Pass a string for 'graduated' to filter devices by graduated value, as per https://conch.joyent.us/doc#getdevices
 // Pass a string for 'health' to filter devices by health value, as per https://conch.joyent.us/doc#getdevices
-func (c *Conch) GetWorkspaceDevices(workspaceUUID fmt.Stringer, idsOnly bool, graduated string, health string) ([]Device, error) {
+func (c *Conch) GetWorkspaceDevices(
+	workspaceUUID fmt.Stringer,
+	idsOnly bool,
+	graduated string,
+	health string,
+	validated string,
+) ([]Device, error) {
 
 	devices := make([]Device, 0)
 
@@ -62,10 +68,12 @@ func (c *Conch) GetWorkspaceDevices(workspaceUUID fmt.Stringer, idsOnly bool, gr
 		IDsOnly   bool   `url:"ids_only,omitempty"`
 		Graduated string `url:"graduated,omitempty"`
 		Health    string `url:"health,omitempty"`
+		Validated string `url:"validated,omitempty"`
 	}{
 		idsOnly,
 		graduated,
 		health,
+		validated,
 	}
 
 	url := "/workspace/" + workspaceUUID.String() + "/device"

--- a/pkg/conch/workspaces_test.go
+++ b/pkg/conch/workspaces_test.go
@@ -124,15 +124,24 @@ func TestWorkspaceErrors(t *testing.T) {
 		gock.New(API.BaseURL).Get("/workspace/" + id.String() + "/device").
 			Persist().Reply(400).JSON(ErrApi)
 
-		ret, err := API.GetWorkspaceDevices(id, false, "g", "h")
+		ret, err := API.GetWorkspaceDevices(id, false, "g", "h", "T")
 		st.Expect(t, err, ErrApiUnpacked)
 		st.Expect(t, ret, []conch.Device{})
 
-		ret, err = API.GetWorkspaceDevices(id, true, "g", "h")
+		ret, err = API.GetWorkspaceDevices(id, true, "g", "h", "T")
+		st.Expect(t, err, ErrApiUnpacked)
+		st.Expect(t, ret, []conch.Device{})
+
+		ret, err = API.GetWorkspaceDevices(id, true, "g", "h", "T")
+		st.Expect(t, err, ErrApiUnpacked)
+		st.Expect(t, ret, []conch.Device{})
+
+		ret, err = API.GetWorkspaceDevices(id, true, "g", "h", "F")
 		st.Expect(t, err, ErrApiUnpacked)
 		st.Expect(t, ret, []conch.Device{})
 
 		gock.Flush()
+
 	})
 
 	t.Run("GetWorkspaceRacks", func(t *testing.T) {


### PR DESCRIPTION
New syntax is `conch ws :id devices --validated="T"` or `conch ws :id devices --validated="F"`

Closes #233 