### PR TITLE
Manage hardware products and profiles using JSON

### DIFF
--- a/pkg/commands/internal/hardware/hardware.go
+++ b/pkg/commands/internal/hardware/hardware.go
@@ -7,15 +7,17 @@
 package hardware
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"text/template"
+
 	"github.com/jawher/mow.cli"
 	"github.com/joyent/conch-shell/pkg/conch"
 	"github.com/joyent/conch-shell/pkg/util"
 	uuid "gopkg.in/satori/go.uuid.v1"
-	"io/ioutil"
-	"os"
-	"text/template"
 )
 
 const singleHWPTemplate = `
@@ -68,6 +70,66 @@ ID: {{ .ID }}
         Slots: {{ .Profile.NvmeSsdSlots }}
     {{ end }}
 `
+
+func generateDumpableProduct(p conch.HardwareProduct) interface{} {
+	// This is all to unhide empty fields marked 'omitempty' in the main
+	// struct
+	profile := p.Profile
+	dumpProfile := struct {
+		*conch.HardwareProfile
+		HbaFirmware  string `json:"hba_firmware"`
+		NvmeSsdNum   int    `json:"nvme_ssd_num"`
+		NvmeSsdSize  int    `json:"nvme_ssd_size"`
+		NvmeSsdSlots string `json:"nvme_ssd_slots"`
+		RaidLunNum   int    `json:"raid_lun_num"`
+		SataHddNum   int    `json:"sata_hdd_num"`
+		SataHddSize  int    `json:"sata_hdd_size"`
+		SataHddSlots string `json:"sata_hdd_slots"`
+		SataSsdNum   int    `json:"sata_ssd_num"`
+		SataSsdSize  int    `json:"sata_ssd_size"`
+		SataSsdSlots string `json:"sata_ssd_slots"`
+		TotalPSU     int    `json:"psu_total"`
+
+		ID bool `json:"id,omitempty"`
+	}{
+		HardwareProfile: &profile,
+		HbaFirmware:     profile.HbaFirmware,
+		NvmeSsdNum:      profile.NvmeSsdNum,
+		NvmeSsdSize:     profile.NvmeSsdSize,
+		NvmeSsdSlots:    profile.NvmeSsdSlots,
+		RaidLunNum:      profile.RaidLunNum,
+		SataHddNum:      profile.SataHddNum,
+		SataHddSize:     profile.SataHddSize,
+		SataHddSlots:    profile.SataHddSlots,
+		SataSsdNum:      profile.SataSsdNum,
+		SataSsdSize:     profile.SataSsdSize,
+		SataSsdSlots:    profile.SataSsdSlots,
+		TotalPSU:        profile.TotalPSU,
+	}
+
+	dumpStruct := struct {
+		*conch.HardwareProduct
+		Prefix            string      `json:"prefix"`
+		GenerationName    string      `json:"generation_name"`
+		LegacyProductName string      `json:"legacy_product_name"`
+		SKU               string      `json:"sku"`
+		Profile           interface{} `json:"hardware_product_profile"`
+
+		Specification bool `json:"specification,omitempty"`
+		Created       bool `json:"created,omitempty"`
+		Updated       bool `json:"updated,omitempty"`
+		ID            bool `json:"id,omitempty"`
+	}{
+		HardwareProduct:   &p,
+		Prefix:            p.Prefix,
+		GenerationName:    p.GenerationName,
+		LegacyProductName: p.LegacyProductName,
+		SKU:               p.SKU,
+		Profile:           dumpProfile,
+	}
+
+	return dumpStruct
+}
 
 func getOne(app *cli.Cmd) {
 	app.Action = func() {
@@ -366,5 +428,170 @@ func updateOne(app *cli.Cmd) {
 			util.JSONOut(ret)
 			return
 		}
+	}
+}
+
+func dumpTemplate(cmd *cli.Cmd) {
+	// My kingdom for comments in JSON
+
+	cmd.LongDesc = `This is a JSON template for a hardware product, including its hardware profile.
+It is used in creating a new hardware product and profile. If you need to update a product and profile, see "conch hardware product :id import".
+
+The specification field of the hardware product is explicitly not supported here since dedicated commands exist to deal with those.
+
+JSON does not allow comments so the following is an example with the required fields marked clearly.
+
+{
+     "name": "",  # REQUIRED
+     "alias": "", # REQUIRED
+     "hardware_vendor_id": "00000000-0000-0000-0000-000000000000", # REQUIRED - see "conch hardware vendors"
+     "prefix": "",
+     "generation_name": "",
+     "legacy_product_name": "",
+     "sku": "",
+     "hardware_product_profile": {
+          "bios_firmware": "", # REQUIRED
+          "cpu_type": "",      # REQUIRED
+          "cpu_num": 0,        # REQUIRED
+          "dimms_num": 0,      # REQUIRED
+          "nics_num": 0,       # REQUIRED
+          "usb_num": 0,        # REQUIRED
+          "purpose": "",       # REQUIRED
+          "ram_total": 0,      # REQUIRED
+          "rack_unit": 0,      # REQUIRED
+          "sas_hdd_num": 0,
+          "sas_hdd_size": 0,
+          "sas_hdd_slots": "",
+          "hba_firmware": "",
+          "nvme_ssd_num": 0,
+          "nvme_ssd_size": 0,
+          "nvme_ssd_slots": "",
+          "raid_lun_num": 0,
+          "sata_hdd_num": 0,
+          "sata_hdd_size": 0,
+          "sata_hdd_slots": "",
+          "sata_ssd_num": 0,
+          "sata_ssd_size": 0,
+          "sata_ssd_slots": "",
+          "psu_total": 0
+     }
+}
+
+`
+	cmd.Action = func() {
+		util.JSONOutIndent(generateDumpableProduct(conch.HardwareProduct{}))
+	}
+}
+
+func verifyHardwareProduct(p conch.HardwareProduct) {
+	if p.Name == "" {
+		util.Bail(errors.New("'name' field is required"))
+	}
+
+	if p.Alias == "" {
+		util.Bail(errors.New("'alias' field is required"))
+	}
+
+	if uuid.Equal(p.HardwareVendorID, uuid.UUID{}) {
+		util.Bail(errors.New("'hardware_vendor_id' field is required"))
+	}
+
+}
+
+func importNewProductJson(app *cli.Cmd) {
+	var (
+		filePathArg = app.StringArg("FILE", "-", "Path to a JSON file to use as the data source. '-' indicates STDIN")
+	)
+	app.Spec = "FILE"
+	app.Action = func() {
+		var b []byte
+		var err error
+		if *filePathArg == "-" {
+			b, err = ioutil.ReadAll(os.Stdin)
+		} else {
+			b, err = ioutil.ReadFile(*filePathArg)
+		}
+		if err != nil {
+			util.Bail(err)
+		}
+		if len(string(b)) <= 1 {
+			util.Bail(errors.New("no data provided"))
+		}
+
+		p := conch.HardwareProduct{}
+
+		if err := json.Unmarshal(b, &p); err != nil {
+			util.Bail(err)
+		}
+
+		verifyHardwareProduct(p)
+
+		if err := util.API.SaveHardwareProduct(&p); err != nil {
+			util.Bail(err)
+		}
+
+		ret, err := util.API.GetHardwareProduct(p.ID)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		util.JSONOutIndent(ret)
+
+	}
+}
+
+func importChangedProductJson(app *cli.Cmd) {
+	var (
+		filePathArg = app.StringArg("FILE", "-", "Path to a JSON file to use as the data source. '-' indicates STDIN")
+	)
+	app.Spec = "FILE"
+	app.Action = func() {
+
+		p, err := util.API.GetHardwareProduct(ProductUUID)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		var b []byte
+		if *filePathArg == "-" {
+			b, err = ioutil.ReadAll(os.Stdin)
+		} else {
+			b, err = ioutil.ReadFile(*filePathArg)
+		}
+		if err != nil {
+			util.Bail(err)
+		}
+		if len(string(b)) <= 1 {
+			util.Bail(errors.New("no data provided"))
+		}
+
+		id := p.ID
+		if err := json.Unmarshal(b, &p); err != nil {
+			util.Bail(err)
+		}
+		p.ID = id
+
+		verifyHardwareProduct(p)
+
+		if err := util.API.SaveHardwareProduct(&p); err != nil {
+			util.Bail(err)
+		}
+
+		ret, err := util.API.GetHardwareProduct(p.ID)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		util.JSONOutIndent(generateDumpableProduct(ret))
+
+	}
+}
+func exportProductJson(cmd *cli.Cmd) {
+	cmd.Action = func() {
+		p, err := util.API.GetHardwareProduct(ProductUUID)
+		if err != nil {
+			util.Bail(err)
+		}
+		util.JSONOutIndent(generateDumpableProduct(p))
 	}
 }

--- a/pkg/commands/internal/hardware/hardware.go
+++ b/pkg/commands/internal/hardware/hardware.go
@@ -66,14 +66,6 @@ ID: {{ .ID }}
         Count: {{ .Profile.NvmeSsdNum }}
         Size:  {{ .Profile.NvmeSsdSize }}
         Slots: {{ .Profile.NvmeSsdSlots }}
-    {{ end }}{{ if ne .Profile.Zpool.ID.String "00000000-0000-0000-0000-000000000000"}}
-    Zpool: {{ .Profile.Zpool.ID }}
-      Cache:     {{ .Profile.Zpool.Cache }}
-      Log:       {{ .Profile.Zpool.Log }}
-      Disks Per: {{ .Profile.Zpool.DisksPer }}
-      Spare:     {{ .Profile.Zpool.Spare }}
-      VDEV N:    {{ .Profile.Zpool.VdevN }}
-      VDEV T:    {{ .Profile.Zpool.VdevT }}
     {{ end }}
 `
 

--- a/pkg/commands/internal/hardware/hardware.go
+++ b/pkg/commands/internal/hardware/hardware.go
@@ -40,7 +40,7 @@ ID: {{ .ID }}
     NIC Count: {{ .Profile.NumNics }}
     PSU Total: {{ .Profile.TotalPSU }}{{ if .Profile.NumUSB }}
     USB Count: {{ .Profile.NumUSB }}{{ end }}
-		Raid LUN Count {{ .Profile.RaidLunNum }}
+      Raid LUN Count {{ .Profile.RaidLunNum }}
 
     DIMM Count: {{ .Profile.NumDimms }}
     RAM Total:  {{ .Profile.TotalRAM }} GB

--- a/pkg/commands/internal/hardware/init.go
+++ b/pkg/commands/internal/hardware/init.go
@@ -50,6 +50,17 @@ func Init(app *cli.Cli) {
 						createOne,
 					)
 
+					cmd.Command(
+						"template",
+						"Dumping a JSON template for a hardware product. Used in creating a new product and profile",
+						dumpTemplate,
+					)
+
+					cmd.Command(
+						"import",
+						"Import a JSON file that defines a new hardware product",
+						importNewProductJson,
+					)
 				},
 			)
 
@@ -89,6 +100,18 @@ func Init(app *cli.Cli) {
 						"update up",
 						"Update a hardware product",
 						updateOne,
+					)
+
+					cmd.Command(
+						"export",
+						"Dump the JSON representation of a hardware product and profile. Intended for use with 'import'",
+						exportProductJson,
+					)
+
+					cmd.Command(
+						"import",
+						"Update an existing hardware product and profile using a JSON file",
+						importChangedProductJson,
 					)
 
 				},

--- a/pkg/conch/conch.go
+++ b/pkg/conch/conch.go
@@ -7,6 +7,29 @@
 // Package conch provides access to the Conch API
 package conch
 
+/*
+This is a bit of trickery used elsewhere to help make it clear that we are
+omitting fields from json output.
+
+Specifically, you'll see something like
+
+out := type writableFoo {
+	*Foo
+	ID omit `json:"id,omitempty"`
+}{ myFoo }
+
+This gives us a special version of Foo that leaves out the ID field unless we
+explicitly set it in the new structure.
+
+It's a bit ugly and hacky but it's the best solution I've come up with yet,
+rather than repeating the full contents of the structure and just leaving those
+fields out. This at least lets us grow the structure without remembering to
+update it in multiple places and it lets us document explicitly via this 'omit'
+data type that we're leaving stuff out.
+
+*/
+type omit bool
+
 const (
 	// MinimumAPIVersion sets the earliest API version that we support.
 	MinimumAPIVersion = "2.24.0"

--- a/pkg/conch/hardware.go
+++ b/pkg/conch/hardware.go
@@ -56,31 +56,36 @@ func (c *Conch) SaveHardwareProduct(h *HardwareProduct) error {
 		specification = string(j)
 	}
 
+	profile := struct {
+		*HardwareProfile
+		ID          omit `json:"id,omitempty"`
+		Created     omit `json:"created,omitempty"`
+		Updated     omit `json:"updated,omitempty"`
+		Deactivated omit `json:"deactivated,omitempty"`
+	}{HardwareProfile: &h.Profile}
+
 	out := struct {
-		Name              string `json:"name"`
-		Alias             string `json:"alias"`
-		Prefix            string `json:"prefix"`
-		HardwareVendorID  string `json:"hardware_vendor_id"`
-		Specification     string `json:"specification,omitempty"`
-		SKU               string `json:"sku"`
-		GenerationName    string `json:"generation_name"`
-		LegacyProductName string `json:"legacy_product_name"`
+		*HardwareProduct
+		ID            omit        `json:"id,omitempty"`
+		Created       omit        `json:"created,omitempty"`
+		Updated       omit        `json:"updated,omitempty"`
+		Deactivated   omit        `json:"deactivated,omitempty"`
+		Specification string      `json:"specification,omitempty"`
+		Profile       interface{} `json:"hardware_product_profile,omitempty"`
 	}{
-		h.Name,
-		h.Alias,
-		h.Prefix,
-		h.HardwareVendorID.String(),
-		specification,
-		h.SKU,
-		h.GenerationName,
-		h.LegacyProductName,
+		HardwareProduct: h,
+		Specification:   specification,
+		Profile:         profile,
 	}
 
 	if uuid.Equal(h.ID, uuid.UUID{}) {
 		return c.post("/hardware_product", out, &h)
 	} else {
 		return c.post(
-			"/hardware_product/"+h.ID.String(), out, &h)
+			"/hardware_product/"+h.ID.String(),
+			out,
+			&h,
+		)
 	}
 }
 

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -279,24 +279,10 @@ type HardwareProfile struct {
 	NvmeSsdNum   int    `json:"nvme_ssd_num,omitempty"`
 	NvmeSsdSize  int    `json:"nvme_ssd_size,omitempty"`
 	NvmeSsdSlots string `json:"nvme_ssd_slots,omitempty"`
-
-	RaidLunNum int                  `json:"raid_lun_num,omitempty"`
-	TotalPSU   int                  `json:"psu_total,omitempty"`
-	TotalRAM   int                  `json:"ram_total"`
-	RackUnit   int                  `json:"rack_unit"`
-	Zpool      HardwareProfileZpool `json:"zpool_profile,omitempty"`
-}
-
-// HardwareProfileZpool represents the layout of the target device's ZFS zpools
-type HardwareProfileZpool struct {
-	ID       uuid.UUID `json:"id"`
-	Name     string    `json:"name"`
-	Cache    int       `json:"cache"`
-	Log      int       `json:"log"`
-	DisksPer int       `json:"disks_per"`
-	Spare    int       `json:"spare"`
-	VdevN    int       `json:"vdev_n"`
-	VdevT    string    `json:"vdev_t"`
+	RaidLunNum   int    `json:"raid_lun_num,omitempty"`
+	TotalPSU     int    `json:"psu_total,omitempty"`
+	TotalRAM     int    `json:"ram_total"`
+	RackUnit     int    `json:"rack_unit"`
 }
 
 // HardwareVendor ...

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -264,9 +264,9 @@ type HardwareProfile struct {
 	NumUSB       int       `json:"usb_num"`
 	Purpose      string    `json:"purpose"`
 
-	SasHddNum   int    `json:"sas_hdd_num"`
-	SasHddSize  int    `json:"sas_hdd_size"`
-	SasHddSlots string `json:"sas_hdd_slots"`
+	SasHddNum   int    `json:"sas_hdd_num,omitempty"`
+	SasHddSize  int    `json:"sas_hdd_size,omitempty"`
+	SasHddSlots string `json:"sas_hdd_slots,omitempty"`
 
 	SataHddNum   int    `json:"sata_hdd_num,omitempty"`
 	SataHddSize  int    `json:"sata_hdd_size,omitempty"`

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -187,11 +187,11 @@ type HardwareProduct struct {
 	ID                uuid.UUID       `json:"id"`
 	Name              string          `json:"name"`
 	Alias             string          `json:"alias"`
-	Prefix            string          `json:"prefix"`
+	Prefix            string          `json:"prefix,omitempty"`
 	HardwareVendorID  uuid.UUID       `json:"hardware_vendor_id"`
-	GenerationName    string          `json:"generation_name"`
-	LegacyProductName string          `json:"legacy_product_name"`
-	SKU               string          `json:"sku"`
+	GenerationName    string          `json:"generation_name,omitempty"`
+	LegacyProductName string          `json:"legacy_product_name,omitempty"`
+	SKU               string          `json:"sku,omitempty"`
 	Specification     interface{}     `json:"specification"`
 	Profile           HardwareProfile `json:"hardware_product_profile"`
 	Created           pgtime.PgTime   `json:"created"`
@@ -257,7 +257,7 @@ type HardwareProfile struct {
 	ID           uuid.UUID `json:"id"`
 	BiosFirmware string    `json:"bios_firmware"`
 	CPUType      string    `json:"cpu_type"`
-	HbaFirmware  string    `json:"hba_firmware"`
+	HbaFirmware  string    `json:"hba_firmware,omitempty"`
 	NumCPU       int       `json:"cpu_num"`
 	NumDimms     int       `json:"dimms_num"`
 	NumNics      int       `json:"nics_num"`
@@ -268,23 +268,23 @@ type HardwareProfile struct {
 	SasHddSize  int    `json:"sas_hdd_size"`
 	SasHddSlots string `json:"sas_hdd_slots"`
 
-	SataHddNum   int    `json:"sata_hdd_num"`
-	SataHddSize  int    `json:"sata_hdd_size"`
-	SataHddSlots string `json:"sata_hdd_slots"`
+	SataHddNum   int    `json:"sata_hdd_num,omitempty"`
+	SataHddSize  int    `json:"sata_hdd_size,omitempty"`
+	SataHddSlots string `json:"sata_hdd_slots,omitempty"`
 
-	SataSsdNum   int    `json:"sata_ssd_num"`
-	SataSsdSize  int    `json:"sata_ssd_size"`
-	SataSsdSlots string `json:"sata_ssd_slots"`
+	SataSsdNum   int    `json:"sata_ssd_num,omitempty"`
+	SataSsdSize  int    `json:"sata_ssd_size,omitempty"`
+	SataSsdSlots string `json:"sata_ssd_slots,omitempty"`
 
-	NvmeSsdNum   int    `json:"nvme_ssd_num"`
-	NvmeSsdSize  int    `json:"nvme_ssd_size"`
-	NvmeSsdSlots string `json:"nvme_ssd_slots"`
+	NvmeSsdNum   int    `json:"nvme_ssd_num,omitempty"`
+	NvmeSsdSize  int    `json:"nvme_ssd_size,omitempty"`
+	NvmeSsdSlots string `json:"nvme_ssd_slots,omitempty"`
 
-	RaidLunNum int                  `json:"raid_lun_num"`
-	TotalPSU   int                  `json:"psu_total"`
+	RaidLunNum int                  `json:"raid_lun_num,omitempty"`
+	TotalPSU   int                  `json:"psu_total,omitempty"`
 	TotalRAM   int                  `json:"ram_total"`
 	RackUnit   int                  `json:"rack_unit"`
-	Zpool      HardwareProfileZpool `json:"zpool"`
+	Zpool      HardwareProfileZpool `json:"zpool_profile,omitempty"`
 }
 
 // HardwareProfileZpool represents the layout of the target device's ZFS zpools

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -276,9 +276,9 @@ type HardwareProfile struct {
 	SataSsdSize  int    `json:"sata_ssd_size"`
 	SataSsdSlots string `json:"sata_ssd_slots"`
 
-	NvmeSsdNum   int `json:"nvme_ssd_num"`
-	NvmeSsdSize  int `json:"nvme_ssd_size"`
-	NvmeSsdSlots int `json:"nvme_ssd_slots"`
+	NvmeSsdNum   int    `json:"nvme_ssd_num"`
+	NvmeSsdSize  int    `json:"nvme_ssd_size"`
+	NvmeSsdSlots string `json:"nvme_ssd_slots"`
 
 	RaidLunNum int                  `json:"raid_lun_num"`
 	TotalPSU   int                  `json:"psu_total"`


### PR DESCRIPTION
See the commit message on https://github.com/joyent/conch-shell/commit/53fa297e6adca37803fcee1505d6310322889f4d for the UX on the new commands. Closes #236 
Example of `conch hardware products template --help` and of a blank template are up at https://gist.github.com/sungo/44e0c7712557b4ae5408faeae1ca927d

Breaking: this also drops all support for zpool profiles. Closes #238 