### PR TITLE
Better error messages and help for 'workspace :id add-user'

### DIFF
--- a/pkg/commands/internal/workspaces/init.go
+++ b/pkg/commands/internal/workspaces/init.go
@@ -149,7 +149,7 @@ func Init(app *cli.Cli) {
 
 			cmd.Command(
 				"add-user add invite",
-				"Add a user to this workspace, creating them if necessary",
+				"Add an existing user to this workspace",
 				addUser,
 			)
 

--- a/pkg/commands/internal/workspaces/user.go
+++ b/pkg/commands/internal/workspaces/user.go
@@ -1,11 +1,14 @@
 package workspaces
 
 import (
+	"errors"
 	"fmt"
+	"net/mail"
+
 	"github.com/jawher/mow.cli"
+	"github.com/joyent/conch-shell/pkg/conch"
 	"github.com/joyent/conch-shell/pkg/util"
 	uuid "gopkg.in/satori/go.uuid.v1"
-	"net/mail"
 )
 
 func addUser(app *cli.Cmd) {
@@ -60,6 +63,10 @@ Those days are behind us. New users must now be created via the 'admin user' int
 			email,
 			role,
 		)
+
+		if err == conch.ErrDataNotFound {
+			util.Bail(errors.New("data not found. Likely, the user does not exist. See --help for next steps"))
+		}
 
 		if err != nil {
 			util.Bail(err)

--- a/pkg/commands/internal/workspaces/user.go
+++ b/pkg/commands/internal/workspaces/user.go
@@ -15,6 +15,8 @@ func addUser(app *cli.Cmd) {
 	)
 
 	app.Spec = "EMAIL [OPTIONS]"
+	app.LongDesc = `In Days Gone By, one could create a new user while adding them to a workspace.
+Those days are behind us. New users must now be created via the 'admin user' interface.`
 
 	app.Action = func() {
 		var role string


### PR DESCRIPTION
Closes #239 

Previously, one could add a new user to conch by 'inviting' them to a workspace. The API no longer allows this, and users must be created via separate endpoints by systems admins.

The shell's "workspace :id add-user" was documented to create new users if necessary. The "fix" in this PR is to document the new workflow, requiring users to run the "admin user" commands on their own.

I thought about having the add-user command call the new user endpoints on its own. Problem is that users can be admins on a workspace but *not* a system admin. That gives them permission to add a user to the workspace but *not* create a new user. To do things right, I'd need to look up the current user, see if they're an admin, fail if not, then create a user, etc etc. It gets complicated fast and all these checks are already done over in the "admin user" commands. Rather than complicate the code, I chose the route of documentation.

Replicating the old behavior looks something like: `conch admin user myuser@joyent.wat create && conch workspace my-workspace add-user myuser@joyent.wat`