### PR TITLE
Bring the shell closer to parity with the web UI's workflow

### DIFF
--- a/pkg/commands/internal/global/rack.go
+++ b/pkg/commands/internal/global/rack.go
@@ -281,18 +281,27 @@ func rackExportLayout(cmd *cli.Cmd) {
 		}
 
 		var output importLayout
-
-		for _, l := range existingLayout {
-			hw, err := util.API.GetHardwareProduct(l.ProductID)
-			if err != nil {
-				util.Bail(err)
-			}
+		if len(existingLayout) == 0 {
 			output = append(output, importLayoutSlot{
-				RUStart:      l.RUStart,
-				ProductID:    hw.ID,
-				ProductName:  hw.Name,
-				ProductAlias: hw.Alias,
+				RUStart:      0,
+				ProductID:    uuid.UUID{},
+				ProductName:  "Product Name",
+				ProductAlias: "Product Alias",
 			})
+		} else {
+
+			for _, l := range existingLayout {
+				hw, err := util.API.GetHardwareProduct(l.ProductID)
+				if err != nil {
+					util.Bail(err)
+				}
+				output = append(output, importLayoutSlot{
+					RUStart:      l.RUStart,
+					ProductID:    hw.ID,
+					ProductName:  hw.Name,
+					ProductAlias: hw.Alias,
+				})
+			}
 		}
 
 		util.JSONOutIndent(output)

--- a/pkg/commands/internal/workspaces/init.go
+++ b/pkg/commands/internal/workspaces/init.go
@@ -103,6 +103,18 @@ func Init(app *cli.Cli) {
 					cmd.Spec = "ID"
 
 					cmd.Command(
+						"assign",
+						"Assign devices to slots in this rack using JSON artifacts",
+						assignRack,
+					)
+
+					cmd.Command(
+						"assignments",
+						"Dump a JSON extract of the devices assigned to this rack's slots. Intended for use with 'assign'",
+						assignmentsRack,
+					)
+
+					cmd.Command(
 						"get",
 						"Get details about a single rack in a workspace",
 						getRack,

--- a/pkg/commands/internal/workspaces/workspaces.go
+++ b/pkg/commands/internal/workspaces/workspaces.go
@@ -287,10 +287,6 @@ func (b slotByRackUnitStart) Less(i, j int) bool {
 }
 
 func getRack(app *cli.Cmd) {
-	var (
-		slotDetail = app.BoolOpt("slots", false, "Show details about each rack slot")
-	)
-
 	app.Action = func() {
 		rack, err := util.API.GetWorkspaceRack(WorkspaceUUID, RackUUID)
 		if err != nil {
@@ -316,47 +312,45 @@ Datacenter: %s
 			rack.Datacenter,
 		)
 
-		if *slotDetail {
-			fmt.Println()
+		fmt.Println()
 
-			sort.Sort(slotByRackUnitStart(rack.Slots))
+		sort.Sort(slotByRackUnitStart(rack.Slots))
 
-			table := util.GetMarkdownTable()
-			table.SetHeader([]string{
-				"RU",
-				"Occupied",
-				"Name",
-				"Alias",
-				"Vendor",
-				"Occupied By",
-				"Health",
+		table := util.GetMarkdownTable()
+		table.SetHeader([]string{
+			"RU",
+			"Occupied",
+			"Name",
+			"Alias",
+			"Vendor",
+			"Occupied By",
+			"Health",
+		})
+
+		for _, slot := range rack.Slots {
+			occupied := "X"
+
+			occupantID := ""
+			occupantHealth := ""
+
+			if slot.Occupant.ID != "" {
+				occupied = "+"
+				occupantID = slot.Occupant.ID
+				occupantHealth = slot.Occupant.Health
+			}
+
+			table.Append([]string{
+				strconv.Itoa(slot.RackUnitStart),
+				occupied,
+				slot.Name,
+				slot.Alias,
+				slot.Vendor,
+				occupantID,
+				occupantHealth,
 			})
 
-			for _, slot := range rack.Slots {
-				occupied := "X"
-
-				occupantID := ""
-				occupantHealth := ""
-
-				if slot.Occupant.ID != "" {
-					occupied = "+"
-					occupantID = slot.Occupant.ID
-					occupantHealth = slot.Occupant.Health
-				}
-
-				table.Append([]string{
-					strconv.Itoa(slot.RackUnitStart),
-					occupied,
-					slot.Name,
-					slot.Alias,
-					slot.Vendor,
-					occupantID,
-					occupantHealth,
-				})
-
-			}
-			table.Render()
 		}
+		table.Render()
 	}
 }
 

--- a/pkg/commands/internal/workspaces/workspaces.go
+++ b/pkg/commands/internal/workspaces/workspaces.go
@@ -298,14 +298,19 @@ func getRack(app *cli.Cmd) {
 			return
 		}
 
+		workspace, err := util.API.GetWorkspace(WorkspaceUUID)
+		if err != nil {
+			util.Bail(err)
+		}
+
 		fmt.Printf(`
 Workspace: %s
-Rack ID:   %s
 Name: %s
 Role: %s
 Datacenter: %s
+Rack ID:   %s
 `,
-			WorkspaceUUID.String(),
+			workspace.Name,
 			RackUUID.String(),
 			rack.Name,
 			rack.Role,

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -540,3 +540,11 @@ type WorkspaceUser struct {
 	User
 	RoleVia uuid.UUID `json:"role_via,omitempty"`
 }
+
+/* This is a piece of fun from /workspace/:id/rack/:id/layout
+The payload looks like:
+{ "my-device-id": 47 }
+
+Where '47' is the rack unit start for the device
+*/
+type WorkspaceRackLayoutAssignments map[string]int

--- a/pkg/conch/workspaces.go
+++ b/pkg/conch/workspaces.go
@@ -198,3 +198,15 @@ func (c *Conch) AddUserToWorkspace(workspaceUUID fmt.Stringer, user string, role
 func (c *Conch) RemoveUserFromWorkspace(workspaceUUID fmt.Stringer, email string) error {
 	return c.httpDelete("/workspace/" + workspaceUUID.String() + "/user/email=" + email)
 }
+
+func (c *Conch) AssignDevicesToRackSlots(
+	workspaceID fmt.Stringer,
+	rackID fmt.Stringer,
+	assignments WorkspaceRackLayoutAssignments,
+) error {
+	return c.post(
+		"/workspace/"+workspaceID.String()+"/rack/"+rackID.String()+"/layout",
+		assignments,
+		nil,
+	)
+}


### PR DESCRIPTION
New features:
* `conch ws :id rack :id assignments` - dumps a JSON extract of the rack and its slot assignments (similar to opening the rack in the web UI)
* `conch ws :id rack :id assign` - accepts an JSON extract that assigns devices to rack slots (similar to the "Edit Assignments" feature in the web UI)

* `conch ws :id rack :id get` always shows the slot data and now shows validation status. Also now shows the workspace name instead of its ID

Bug Fix: `global rack :id layout export` previously showed the text "null" if no layout was ever created for that rack. It now shows a template blob instead.