### PR TITLE
admin user manipulation improvements

### DIFF
--- a/pkg/commands/internal/admin/init.go
+++ b/pkg/commands/internal/admin/init.go
@@ -8,9 +8,10 @@
 package admin
 
 import (
+	"net/mail"
+
 	"github.com/jawher/mow.cli"
 	"github.com/joyent/conch-shell/pkg/util"
-	"net/mail"
 )
 
 // UserEmail contains the email address of the user being operated on in
@@ -44,8 +45,6 @@ func Init(app *cli.Cli) {
 
 					cmd.Spec = "USER"
 
-					// BUG(sungo): When conch api 2.17 goes to production, we
-					// can verify that the user exists. joyent/conch#341
 					cmd.Before = func() {
 						address, err := mail.ParseAddress(*userIDStr)
 						if err != nil {
@@ -53,6 +52,12 @@ func Init(app *cli.Cli) {
 						}
 						UserEmail = address.Address
 					}
+
+					cmd.Command(
+						"get",
+						"Get the basic info about a user",
+						getUser,
+					)
 
 					cmd.Command(
 						"revoke",
@@ -76,6 +81,24 @@ func Init(app *cli.Cli) {
 						"reset",
 						"Reset the password for the user",
 						resetUserPassword,
+					)
+
+					cmd.Command(
+						"update",
+						"Update properties of the user",
+						updateUser,
+					)
+
+					cmd.Command(
+						"promote",
+						"Promote the user to system admin",
+						promoteUser,
+					)
+
+					cmd.Command(
+						"demote",
+						"Demote the user to a regular user",
+						demoteUser,
 					)
 
 				},

--- a/pkg/commands/internal/admin/main.go
+++ b/pkg/commands/internal/admin/main.go
@@ -106,12 +106,20 @@ func deleteUser(app *cli.Cmd) {
 }
 
 func createUser(app *cli.Cmd) {
+	var (
+		adminOpt = app.BoolOpt("admin", false, "Set user as system admin")
+	)
 	app.Action = func() {
-		if err := util.API.CreateUser(UserEmail, "", ""); err != nil {
+		if err := util.API.CreateUser(UserEmail, "", "", *adminOpt); err != nil {
 			util.Bail(err)
 		}
+
 		if !util.JSON {
-			fmt.Println("User " + UserEmail + " created. An email has been sent containing their new password")
+			if *adminOpt {
+				fmt.Println("Admin user " + UserEmail + " created. An email has been sent containing their new password")
+			} else {
+				fmt.Println("User " + UserEmail + " created. An email has been sent containing their new password")
+			}
 		}
 	}
 }

--- a/pkg/commands/internal/admin/main.go
+++ b/pkg/commands/internal/admin/main.go
@@ -8,10 +8,15 @@ package admin
 
 import (
 	"fmt"
+	"os"
 	"sort"
+	"text/template"
 
+	gotree "github.com/DiSiqueira/GoTree"
 	"github.com/jawher/mow.cli"
+	"github.com/joyent/conch-shell/pkg/conch"
 	"github.com/joyent/conch-shell/pkg/util"
+	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func listAllUsers(app *cli.Cmd) {
@@ -131,6 +136,171 @@ func resetUserPassword(app *cli.Cmd) {
 		}
 		if !util.JSON {
 			fmt.Println("The password for " + UserEmail + " has been reset. An email has been sent containing their new password")
+		}
+	}
+}
+
+const userTemplate = `
+ID: {{ .ID }}
+Name: {{.Name}}
+Email: {{.Email}}
+Is Admin: {{ .IsAdmin }}
+
+Created: {{.Created.Local}}
+Last Login: {{.LastLogin.Local}}
+{{if len .Workspaces}}
+Workspace Permissions Tree:
+{{end}}
+`
+
+func buildWSTree(
+	parents map[string]conch.WorkspacesAndRoles,
+	parent uuid.UUID,
+	tree *gotree.GTStructure,
+) {
+
+	for _, ws := range parents[parent.String()] {
+		sub := gotree.GTStructure{}
+		sub.Name = fmt.Sprintf("%s / %s (%s)", ws.Name, ws.Role, ws.ID.String())
+
+		buildWSTree(parents, ws.ID, &sub)
+		tree.Items = append(tree.Items, sub)
+	}
+}
+
+func getUser(app *cli.Cmd) {
+	app.Action = func() {
+		user, err := util.API.GetUserByEmail(UserEmail)
+		if err != nil {
+			util.Bail(err)
+		}
+		if util.JSON {
+			util.JSONOut(user)
+			return
+		}
+
+		sort.Sort(user.Workspaces)
+
+		t, err := template.New("up").Parse(userTemplate)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		if err := t.Execute(os.Stdout, user); err != nil {
+			util.Bail(err)
+		}
+
+		if len(user.Workspaces) > 0 {
+			workspaces := make(map[string]conch.WorkspaceAndRole)
+			for _, ws := range user.Workspaces {
+				workspaces[ws.ID.String()] = ws
+			}
+
+			roots := make([]uuid.UUID, 0)
+
+			parents := make(map[string]conch.WorkspacesAndRoles)
+
+			for _, ws := range workspaces {
+				if uuid.Equal(ws.RoleVia, uuid.UUID{}) {
+					roots = append(roots, ws.ID)
+				} else {
+					if _, ok := parents[ws.RoleVia.String()]; !ok {
+						parents[ws.RoleVia.String()] = make(conch.WorkspacesAndRoles, 0)
+					}
+					parents[ws.RoleVia.String()] = append(
+						parents[ws.RoleVia.String()],
+						ws,
+					)
+					sort.Sort(parents[ws.RoleVia.String()])
+				}
+			}
+
+			for _, rootID := range roots {
+				tree := gotree.GTStructure{}
+				root := workspaces[rootID.String()]
+				tree.Name = fmt.Sprintf("%s / %s (%s)", root.Name, root.Role, root.ID.String())
+
+				buildWSTree(parents, rootID, &tree)
+				gotree.PrintTree(tree)
+			}
+		}
+
+	}
+
+}
+
+func updateUser(app *cli.Cmd) {
+	var (
+		emailOpt = app.StringOpt("email", "", "Change the user's email address")
+		nameOpt  = app.StringOpt("name", "", "Set the user's name")
+	)
+	app.Action = func() {
+
+		user, err := util.API.GetUserByEmail(UserEmail)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		// I'm not supporting admin status here because it's not possible to
+		// know if the user set the flag to false because they want to revoke
+		// admin status or if they just didn't provide it.
+		if err := util.API.UpdateUser(
+			user.ID,
+			*emailOpt,
+			*nameOpt,
+			user.IsAdmin,
+		); err != nil {
+			util.Bail(err)
+		}
+
+		if !util.JSON {
+			fmt.Println("User " + UserEmail + " updated")
+		}
+	}
+}
+
+func promoteUser(app *cli.Cmd) {
+	app.Action = func() {
+
+		user, err := util.API.GetUserByEmail(UserEmail)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		if err := util.API.UpdateUser(
+			user.ID,
+			user.Email,
+			user.Name,
+			true,
+		); err != nil {
+			util.Bail(err)
+		}
+
+		if !util.JSON {
+			fmt.Println("User " + UserEmail + " promoted to system admin")
+		}
+	}
+}
+
+func demoteUser(app *cli.Cmd) {
+	app.Action = func() {
+
+		user, err := util.API.GetUserByEmail(UserEmail)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		if err := util.API.UpdateUser(
+			user.ID,
+			user.Email,
+			user.Name,
+			false,
+		); err != nil {
+			util.Bail(err)
+		}
+
+		if !util.JSON {
+			fmt.Println("User " + UserEmail + " demoted to regular user")
 		}
 	}
 }

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -408,7 +408,7 @@ type UserDetailed struct {
 	LastLogin           pgtime.PgTime      `json:"last_login"`
 	RefuseSessionAuth   bool               `json:"refuse_session_auth"`
 	ForcePasswordChange bool               `json:"force_password_change"`
-	Workspaces          []WorkspaceAndRole `json:"workspaces,omitempty"`
+	Workspaces          WorkspacesAndRoles `json:"workspaces,omitempty"`
 	IsAdmin             bool               `json:"is_admin"`
 }
 

--- a/pkg/conch/user.go
+++ b/pkg/conch/user.go
@@ -50,14 +50,21 @@ func (c *Conch) DeleteUser(emailAddress string, clearTokens bool) error {
 }
 
 // CreateUser creates a new user. They are *not* added to a workspace.
-// The 'name' argument is optional and will be omitted if set to ""
-// The 'password' argument is optional and will be omitted if set to ""
-func (c *Conch) CreateUser(email string, password string, name string) error {
+// The 'email' argument is required.
+// The 'name' argument is optional
+// The 'password' argument is optional
+// The 'isAdmin' argument sets the user to be an admin. Defaults to false.
+func (c *Conch) CreateUser(email string, password string, name string, isAdmin bool) error {
+	if email == "" {
+		return ErrBadInput
+	}
+
 	u := struct {
 		Email    string `json:"email"`
 		Password string `json:"password,omitempty"`
 		Name     string `json:"name,omitempty"`
-	}{email, password, name}
+		IsAdmin  bool   `json:"is_admin"`
+	}{email, password, name, isAdmin}
 
 	return c.post("/user", u, nil)
 }

--- a/pkg/conch/user_test.go
+++ b/pkg/conch/user_test.go
@@ -69,7 +69,11 @@ func TestUserErrors(t *testing.T) {
 
 	t.Run("CreateUser", func(t *testing.T) {
 		gock.New(API.BaseURL).Post("/user").Reply(400).JSON(ErrApi)
-		err := API.CreateUser("foo@bar.bat", "", "")
+		err := API.CreateUser("foo@bar.bat", "", "", false)
+		st.Expect(t, err, ErrApiUnpacked)
+
+		gock.New(API.BaseURL).Post("/user").Reply(400).JSON(ErrApi)
+		err = API.CreateUser("foo@bar.bat", "", "", true)
 		st.Expect(t, err, ErrApiUnpacked)
 	})
 


### PR DESCRIPTION
* Users may now be created as a system admin
  * `conch admin user :email create` now takes an optional `--admin` flag which sets the user as a system admin

* Admins can now view detailed information about a user, including their permissions tree
  * Added: `conch admin user :email get`

* Admins can now update the user's name and email address
  * Added: `conch admin user :email update --name :name --email :email`

* Admins can now promote a user to system admin status and demote them back to a regular user
  * Added: `conch admin user :email promote`
  * Added: `conch admin user :email demote`

Closes #248 