### PR TITLE
conch.WorkspaceRelays are now sortable, by updated time

### DIFF
--- a/pkg/conch/relays.go
+++ b/pkg/conch/relays.go
@@ -30,7 +30,7 @@ func (c *Conch) GetActiveWorkspaceRelays(
 }
 
 // GetWorkspaceRelays returns all Relays associated with the given workspace
-func (c *Conch) GetWorkspaceRelays(workspaceUUID fmt.Stringer) ([]WorkspaceRelay, error) {
+func (c *Conch) GetWorkspaceRelays(workspaceUUID fmt.Stringer) (WorkspaceRelays, error) {
 	relays := make([]WorkspaceRelay, 0)
 
 	url := "/workspace/" + workspaceUUID.String() + "/relay"
@@ -77,7 +77,7 @@ func (c *Conch) RegisterRelay(r WorkspaceRelay) error {
 
 // GetAllRelays uses the /relay endpoint to get a list of all
 // relays, but without their assigned devices.
-func (c *Conch) GetAllRelays() ([]WorkspaceRelay, error) {
+func (c *Conch) GetAllRelays() (WorkspaceRelays, error) {
 	relays := make([]WorkspaceRelay, 0)
 	return relays, c.get("/relay?no_devices=1", &relays)
 }

--- a/pkg/conch/relays_test.go
+++ b/pkg/conch/relays_test.go
@@ -27,7 +27,7 @@ func TestRelayErrors(t *testing.T) {
 
 		ret, err := API.GetWorkspaceRelays(id)
 		st.Expect(t, err, ErrApiUnpacked)
-		st.Expect(t, ret, []conch.WorkspaceRelay{})
+		st.Expect(t, ret, conch.WorkspaceRelays{})
 	})
 
 	t.Run("RegisterRelay", func(t *testing.T) {
@@ -47,7 +47,7 @@ func TestRelayErrors(t *testing.T) {
 
 		ret, err := API.GetAllRelays()
 		st.Expect(t, err, ErrApiUnpacked)
-		st.Expect(t, ret, []conch.WorkspaceRelay{})
+		st.Expect(t, ret, conch.WorkspaceRelays{})
 	})
 
 }

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -520,6 +520,18 @@ type ValidationState struct {
 // WorkspaceRelays ...
 type WorkspaceRelays []WorkspaceRelay
 
+func (w WorkspaceRelays) Len() int {
+	return len(w)
+}
+
+func (w WorkspaceRelays) Swap(i, j int) {
+	w[i], w[j] = w[j], w[i]
+}
+
+func (w WorkspaceRelays) Less(i, j int) bool {
+	return w[i].Updated.Before(w[j].Updated.Time)
+}
+
 // WorkspaceRelay represents a Conch Relay unit, a physical piece of hardware that
 // mediates Livesys interactions in the field
 type WorkspaceRelay struct {


### PR DESCRIPTION
GetWorkspaceRelays and GetAllRelays now return conch.WorkspaceRelays