### PR TITLE
Fixes an auth bug that prevented concurrent usage

### DIFF
--- a/pkg/conch/auth.go
+++ b/pkg/conch/auth.go
@@ -43,8 +43,7 @@ func (c *Conch) RevokeOwnTokens() error {
 	return nil
 }
 
-// VerifyLogin determines if the user's session data is still valid. If
-// available, it uses the refresh API, falling back to plain cookie auth.
+// VerifyLogin determines if the user's session data is still valid.
 //
 // One can pass in an integer value, representing when to force a token
 // refresh, based on the number of seconds left until expiry. Pass in 0 to

--- a/pkg/conch/auth.go
+++ b/pkg/conch/auth.go
@@ -58,7 +58,7 @@ func (c *Conch) VerifyLogin(refreshTime int, forceJWT bool) error {
 	if !forceJWT {
 		if (refreshTime > 0) && !c.JWT.Expires.IsZero() {
 			now := time.Now()
-			if now.Sub(c.JWT.Expires).Seconds() > float64(refreshTime) {
+			if c.JWT.Expires.Sub(now).Seconds() > float64(refreshTime) {
 				return nil
 			}
 		}


### PR DESCRIPTION
Closes #263 

The bug is caused a reversal in subtraction when figuring out if the JWT should be refreshed. This broke concurrent usage (and probably locked the user out of the web ui too). The path looks like this:

* The user executes a command
* The command calls VerifyLogin(). VerifyLogin, when figuring out if the token should be refreshed, subtracted `then` from `now` which always results in a negative value
* Thinking the token should be refreshed, VerifyLogin() calls `/refresh_token`, invalidating all outstanding tokens
* The new token is written out to the config

This is where most users exit stage left. They were only executing a single command and all went well. They've got a shiny new token in the config and the next command will work just fine.

If the user is running commands at the same time in different windows, however, a race condition exists where one instance invalidates the tokens but doesn't write out the config file before another instance accesses it. This can also occur if a second instance invalidates the tokens while the first instance is executing code with multiple API calls. 

To test, I ran the command in three different windows:
```
for i in `bin/conch ws GLOBAL devices --ids-only`; do 
  bin/conch d $i ipmi
done
```