### PR TITLE
Version pinning

### DIFF
--- a/cmd/conch/conch.go
+++ b/cmd/conch/conch.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/blang/semver"
 	"github.com/jawher/mow.cli"
 	"github.com/joyent/conch-shell/pkg/commands"
 	"github.com/joyent/conch-shell/pkg/conch"
@@ -96,30 +95,29 @@ func main() {
 		}
 
 		checkVersion := true
-		if *noVersion {
-			checkVersion = false
-		}
-
-		if cfg.SkipVersionCheck {
+		if *noVersion || cfg.SkipVersionCheck {
 			checkVersion = false
 		}
 
 		if checkVersion {
 			gh, err := util.LatestGithubRelease("joyent", "conch-shell")
-			if err != nil {
+			if (err != nil) && (err != util.ErrNoGithubRelease) {
 				util.Bail(err)
 			}
+			if gh.Upgrade {
+				os.Stderr.WriteString(fmt.Sprintf(`
+A new release is available! You have v%s but %s is available.
+The changelog can be viewed via 'conch update changelog'
 
-			if gh.SemVer.GT(semver.MustParse(util.Version)) {
-				os.Stderr.WriteString(fmt.Sprintf(
-					"** A new release is available! You have v%s and %s is available.\n",
+You can obtain the new release by:
+  * Running 'conch update self', which will attempt to overwrite the current application
+  * Manually download the new release at %s
+
+`,
 					util.Version,
 					gh.TagName,
+					gh.URL,
 				))
-				os.Stderr.WriteString(fmt.Sprintf("   The changelog can be viewed via 'conch update changelog'\n\n"))
-				os.Stderr.WriteString(fmt.Sprintln("   You can obtain the new release by:"))
-				os.Stderr.WriteString(fmt.Sprintln("     * Running 'conch update self', which will attempt to overwrite the current application"))
-				os.Stderr.WriteString(fmt.Sprintf("     * Download the new release at %s and manually install it\n\n", gh.URL))
 			}
 		}
 

--- a/cmd/conch/conch.go
+++ b/cmd/conch/conch.go
@@ -100,7 +100,7 @@ func main() {
 		}
 
 		if checkVersion {
-			gh, err := util.LatestGithubRelease("joyent", "conch-shell")
+			gh, err := util.LatestGithubRelease()
 			if (err != nil) && (err != util.ErrNoGithubRelease) {
 				util.Bail(err)
 			}

--- a/cmd/conch/conch.go
+++ b/cmd/conch/conch.go
@@ -41,12 +41,13 @@ func main() {
 						"  Git Revision: %s\n"+
 						"  Build Time: %s\n"+
 						"  Build Host: %s\n"+
-						"  Requires API version: >= %s\n",
+						"  Requires API version: >= %s and < %s\n",
 					util.Version,
 					util.GitRev,
 					buildTime,
 					util.BuildHost,
 					conch.MinimumAPIVersion,
+					conch.BreakingAPIVersion,
 				)
 			}
 		},

--- a/pkg/commands/internal/update/main.go
+++ b/pkg/commands/internal/update/main.go
@@ -25,7 +25,7 @@ import (
 
 func status(cmd *cli.Cmd) {
 	cmd.Action = func() {
-		gh, err := util.LatestGithubRelease("joyent", "conch-shell")
+		gh, err := util.LatestGithubRelease()
 		if err != nil {
 			if err == util.ErrNoGithubRelease {
 				fmt.Printf(
@@ -82,7 +82,7 @@ func selfUpdate(cmd *cli.Cmd) {
 		"Update the binary even if it appears we are on the current release",
 	)
 	cmd.Action = func() {
-		gh, err := util.LatestGithubRelease("joyent", "conch-shell")
+		gh, err := util.LatestGithubRelease()
 
 		if err != nil {
 			if err == util.ErrNoGithubRelease {

--- a/pkg/conch/conch.go
+++ b/pkg/conch/conch.go
@@ -32,7 +32,8 @@ type omit bool
 
 const (
 	// MinimumAPIVersion sets the earliest API version that we support.
-	MinimumAPIVersion = "2.24.0"
+	MinimumAPIVersion  = "2.24.0"
+	BreakingAPIVersion = "3.0.0"
 )
 
 // GetVersion returns the API's version string, via /version

--- a/pkg/util/github.go
+++ b/pkg/util/github.go
@@ -1,0 +1,168 @@
+// Copyright Joyent, Inc.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package util contains common routines used throughout the command base
+package util
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/blang/semver"
+	"github.com/dghubble/sling"
+)
+
+const GhOrg = "joyent"
+const GhRepo = "conch-shell"
+
+// GithubRelease represents a 'release' for a Github project
+type GithubRelease struct {
+	URL     string         `json:"html_url"`
+	TagName string         `json:"tag_name"`
+	SemVer  semver.Version `json:"-"` // Will be set to 0.0.0 if no releases are found
+	Body    string         `json:"body"`
+	Name    string         `json:"name"`
+	Assets  []GithubAsset  `json:"assets"`
+	Upgrade bool           `json:"-"`
+}
+
+type GithubReleases []GithubRelease
+
+func (g GithubReleases) Len() int {
+	return len(g)
+}
+
+func (g GithubReleases) Swap(i, j int) {
+	g[i], g[j] = g[j], g[i]
+}
+
+func (g GithubReleases) Less(i, j int) bool {
+	var iSem, jSem semver.Version
+
+	if g[i].TagName == "" {
+		iSem = semver.MustParse("0.0.0")
+	} else {
+		iSem = semver.MustParse(
+			strings.TrimLeft(g[i].TagName, "v"),
+		)
+	}
+
+	if g[j].TagName == "" {
+		jSem = semver.MustParse("0.0.0")
+	} else {
+		jSem = semver.MustParse(
+			strings.TrimLeft(g[j].TagName, "v"),
+		)
+	}
+
+	return iSem.GT(jSem) // reversing sort
+}
+
+// GithubAsset represents a file inside of a github release
+type GithubAsset struct {
+	URL                string `json:"url"`
+	Name               string `json:"name"`
+	State              string `json:"state"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+var ErrNoGithubRelease = errors.New("no appropriate github release found")
+
+// LatestGithubRelease returns some fields from the latest Github Release
+// that matches our major version
+func LatestGithubRelease() (gh GithubRelease, err error) {
+	releases := make(GithubReleases, 0)
+
+	url := fmt.Sprintf(
+		"https://api.github.com/repos/%s/%s/releases",
+		GhOrg,
+		GhRepo,
+	)
+
+	_, err = sling.New().
+		Set("User-Agent", UserAgent).
+		Get(url).Receive(&releases, nil)
+
+	if err != nil {
+		return gh, err
+	}
+
+	sort.Sort(releases)
+
+	for _, r := range releases {
+		if r.TagName == "" {
+			continue
+		}
+		r.SemVer = CleanVersion(
+			strings.TrimLeft(r.TagName, "v"),
+		)
+
+		if r.SemVer.Major == SemVersion.Major {
+			if r.SemVer.GT(SemVersion) {
+				r.Upgrade = true
+			}
+			return r, nil
+		}
+	}
+
+	return gh, ErrNoGithubRelease
+}
+
+func GithubReleasesSince(start semver.Version) GithubReleases {
+	releases := make(GithubReleases, 0)
+
+	diff := make(GithubReleases, 0)
+
+	url := fmt.Sprintf(
+		"https://api.github.com/repos/%s/%s/releases",
+		GhOrg,
+		GhRepo,
+	)
+
+	_, err := sling.New().
+		Set("User-Agent", UserAgent).
+		Get(url).Receive(&releases, nil)
+
+	if err != nil {
+		return diff
+	}
+
+	sort.Sort(releases)
+
+	for _, r := range releases {
+		if r.TagName == "" {
+			continue
+		}
+		r.SemVer = CleanVersion(
+			strings.TrimLeft(r.TagName, "v"),
+		)
+
+		if r.SemVer.Major == SemVersion.Major {
+			if r.SemVer.GT(start) {
+				diff = append(diff, r)
+			}
+		}
+	}
+
+	sort.Sort(diff)
+
+	return diff
+}
+
+// CleanVersion removes a "v" prefix, and anything after a dash
+// For example, pass in v2.99.10-abcde-dirty and get back a semver containing
+// 2.29.10
+// Why? Git and Semver differ in their notions of what those extra bits mean.
+// In Git, they mean "v2.99.10, plus some other stuff that happend". In semver,
+// they indicate that this is a prerelease of v2.99.10. Obviously this screws
+// up comparisions. This function lets us clean that stuff out so we can get a
+// clean comparison
+func CleanVersion(version string) semver.Version {
+	bits := strings.Split(strings.TrimLeft(version, "v"), "-")
+	return semver.MustParse(bits[0])
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -67,6 +67,9 @@ func init() {
 	SemVersion = semver.MustParse(Version)
 }
 
+const GhOrg = "joyent"
+const GhRepo = "conch-shell"
+
 // DateFormat should be used in date formatting calls to ensure uniformity of
 // output
 const DateFormat = "2006-01-02 15:04:05 -0700 MST"
@@ -367,15 +370,14 @@ type GithubAsset struct {
 var ErrNoGithubRelease = errors.New("no appropriate github release found")
 
 // LatestGithubRelease returns some fields from the latest Github Release
-// object for the given owner and repo via
-// "https://api.github.com/repos/:owner/:repo/releases/latest"
-func LatestGithubRelease(owner string, repo string) (gh GithubRelease, err error) {
+// that matches our major version
+func LatestGithubRelease() (gh GithubRelease, err error) {
 	releases := make(GithubReleases, 0)
 
 	url := fmt.Sprintf(
 		"https://api.github.com/repos/%s/%s/releases",
-		owner,
-		repo,
+		GhOrg,
+		GhRepo,
 	)
 
 	_, err = sling.New().

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -116,6 +116,23 @@ func BuildAPI() {
 	if UserAgent != "" {
 		API.UA = UserAgent
 	}
+
+	version, err := API.GetVersion()
+	if err != nil {
+		Bail(err)
+	}
+
+	sem := semver.MustParse(strings.TrimLeft(version, "v"))
+	minSem := semver.MustParse(conch.MinimumAPIVersion)
+
+	if sem.Major != minSem.Major {
+		Bail(fmt.Errorf(
+			"cannot continue. the major version of API server '%s' is '%d' and we require '%d'",
+			API.BaseURL,
+			sem.Major,
+			minSem.Major,
+		))
+	}
 }
 
 // GetMarkdownTable returns a tablewriter configured to output markdown

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Bowery/prompt"
 	"github.com/blang/semver"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/dghubble/sling"
 	cli "github.com/jawher/mow.cli"
 	"github.com/joyent/conch-shell/pkg/conch"
@@ -408,4 +409,20 @@ func InteractiveForcePasswordChange() {
 	ActiveProfile.JWT = API.JWT
 
 	WriteConfig()
+}
+
+// DDP pretty prints a structure to stderr. "Deep Data Printer"
+func DDP(v interface{}) {
+	spew.Fdump(
+		os.Stderr,
+		v,
+	)
+}
+
+func init() {
+	spew.Config = spew.ConfigState{
+		Indent:                  "    ",
+		SortKeys:                true,
+		DisablePointerAddresses: true,
+	}
 }


### PR DESCRIPTION
* Pins the shell to a major version. Shell v1.11 will not show or attempt to upgrade to v2. Closes #266 
* Lock the shell into a major API version. If the shell expects API v2.24 as its minimum, the shell will refuse to talk to API v3. Closes #267 
* Locks the shell into an API version range. Currently set to >=2.24.0 and <3. The shell will refuse to work with an API of an inappropriate version. Closes #268 
* `conch update changelog` will show all changelogs between the current version and the latest, rather than just the latest. This prevents the user from missing notification of changes that happened in the middle
