### PR TITLE
Remove "workspace :id rooms"

### DIFF
--- a/pkg/commands/internal/workspaces/init.go
+++ b/pkg/commands/internal/workspaces/init.go
@@ -142,12 +142,6 @@ func Init(app *cli.Cli) {
 			)
 
 			cmd.Command(
-				"rooms",
-				"Get a list of rooms for a single workspace",
-				getRooms,
-			)
-
-			cmd.Command(
 				"subs subworkspaces ws",
 				"Get a list of subworkspaces for a single workspace",
 				getSubs,

--- a/pkg/commands/internal/workspaces/workspaces.go
+++ b/pkg/commands/internal/workspaces/workspaces.go
@@ -462,30 +462,6 @@ func getRelays(app *cli.Cmd) {
 	}
 }
 
-func getRooms(app *cli.Cmd) {
-	app.Action = func() {
-		rooms, err := util.API.GetWorkspaceRooms(WorkspaceUUID)
-		if err != nil {
-			util.Bail(err)
-		}
-
-		if util.JSON {
-			util.JSONOut(rooms)
-			return
-		}
-
-		table := util.GetMarkdownTable()
-		table.SetHeader([]string{"ID", "AZ", "Alias", "Vendor Name"})
-
-		for _, r := range rooms {
-			table.Append([]string{r.ID, r.AZ, r.Alias, r.VendorName})
-		}
-
-		table.Render()
-	}
-
-}
-
 func getSubs(app *cli.Cmd) {
 	app.Action = func() {
 		workspaces, err := util.API.GetSubWorkspaces(WorkspaceUUID)

--- a/pkg/conch/workspaces.go
+++ b/pkg/conch/workspaces.go
@@ -133,16 +133,6 @@ func (c *Conch) GetWorkspaceUsers(workspaceUUID fmt.Stringer) ([]WorkspaceUser, 
 	)
 }
 
-// GetWorkspaceRooms returns the contents of /workspace/:uuid/room, getting
-// a list of rooms for the given workspace id
-func (c *Conch) GetWorkspaceRooms(workspaceUUID fmt.Stringer) ([]Room, error) {
-	rooms := make([]Room, 0)
-	return rooms, c.get(
-		"/workspace/"+workspaceUUID.String()+"/room",
-		&rooms,
-	)
-}
-
 // CreateSubWorkspace creates a sub workspace under the parent, via
 // /workspace/:uuid/child
 // If the provided parent lacks an ID, ErrBadInput is returned

--- a/pkg/conch/workspaces_test.go
+++ b/pkg/conch/workspaces_test.go
@@ -65,16 +65,6 @@ func TestWorkspaceErrors(t *testing.T) {
 		st.Expect(t, ret, []conch.WorkspaceUser{})
 	})
 
-	t.Run("GetWorkspaceRooms", func(t *testing.T) {
-		id := uuid.NewV4()
-		gock.New(API.BaseURL).Get("/workspace/" + id.String() + "/room").
-			Reply(400).JSON(ErrApi)
-
-		ret, err := API.GetWorkspaceRooms(id)
-		st.Expect(t, err, ErrApiUnpacked)
-		st.Expect(t, ret, []conch.Room{})
-	})
-
 	t.Run("CreateSubWorkspace", func(t *testing.T) {
 		id := uuid.NewV4()
 		id2 := uuid.NewV4()


### PR DESCRIPTION
As per joyent/conch-shell#269 and  joyent/conch#692, the API has removed the association of rooms to workspaces.

Our "workspace :id rooms" command is no more.

Closes #269 