### PR TITLE
--alias is required for "global rooms create"

### DIFF
--- a/pkg/commands/internal/global/room.go
+++ b/pkg/commands/internal/global/room.go
@@ -94,7 +94,7 @@ func roomCreate(app *cli.Cmd) {
 		aliasOpt      = app.StringOpt("alias", "", "Room Alias")
 		vendorNameOpt = app.StringOpt("vendor-name vn", "", "Vendor Name")
 	)
-	app.Spec = "--datacenter-id --az [OPTIONS]"
+	app.Spec = "--datacenter-id --az --alias [OPTIONS]"
 
 	app.Action = func() {
 		dcID, err := uuid.FromString(*dcIDOpt)

--- a/pkg/conch/global_datacenter_room.go
+++ b/pkg/conch/global_datacenter_room.go
@@ -33,10 +33,14 @@ func (c *Conch) SaveGlobalRoom(r *GlobalRoom) error {
 		return ErrBadInput
 	}
 
+	if r.Alias == "" {
+		return ErrBadInput
+	}
+
 	j := struct {
 		Datacenter string `json:"datacenter"`
 		AZ         string `json:"az"`
-		Alias      string `json:"alias,omitempty"`
+		Alias      string `json:"alias"`
 		VendorName string `json:"vendor_name,omitempty"`
 	}{r.DatacenterID.String(), r.AZ, r.Alias, r.VendorName}
 


### PR DESCRIPTION
Closes #260 

Needs backporting to 1.10 since this change is live in API 2.24