### PR TITLE
Rework SubmitDeviceReport and api tester to use the new payload from posting a device report

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -18,5 +18,5 @@ RUN git clone --branch $BRANCH https://github.com/joyent/conch-shell conch-shell
 WORKDIR /go/src/github.com/joyent/conch-shell
 
 ENTRYPOINT ["make" ]
-CMD [ "release", "checksums" ]
+CMD [ "release", "tester_release", "checksums" ]
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BUILD_ARGS = -ldflags="-X ${FLAGS_PATH}.BuildHost=${BUILD_WHO} -X ${FLAGS_PATH}.
 
 BUILD = go build ${BUILD_ARGS} 
 
-default: clean vendor check bin/conch ## By default, run 'clean', 'check', 'bin/conch'
+default: clean vendor check bin/conch bin/tester ## By default, run 'clean', 'check', 'bin/conch', 'bin/tester'
 
 first-run: tools ## Install all the dependencies needed to build and test
 
@@ -81,7 +81,7 @@ help: ## Display this help message
 	@grep -E '^[a-zA-Z_.-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 
-bin/tester: internal/pkg/cmd/tester/*.go cmd/tester/*.go vendor fasttest ## Build bin/tester
+bin/tester: internal/pkg/cmd/tester/*.go cmd/tester/*.go vendor ## Build bin/tester
 	@echo "==> building bin/tester"
 	go build ${BUILD_ARGS} -o bin/tester cmd/tester/main.go
 

--- a/Makefile
+++ b/Makefile
@@ -86,3 +86,11 @@ bin/tester: internal/pkg/cmd/tester/*.go cmd/tester/*.go vendor fasttest ## Buil
 	go build ${BUILD_ARGS} -o bin/tester cmd/tester/main.go
 
 
+.PHONY: tester_release
+tester_release: vendor check  ## Build binaries for conch-api-tester
+	@echo "==> Building conch-api-tester for all the platforms"
+	GOOS=darwin GOARCH=amd64 ${BUILD} -o release/conch-api-tester-darwin-amd64 cmd/tester/main.go
+	GOOS=linux GOARCH=amd64 ${BUILD} -o release/conch-api-tester-linux-amd64 cmd/tester/main.go
+	GOOS=solaris GOARCH=amd64 ${BUILD} -o release/conch-api-tester-solaris-amd64 cmd/tester/main.go
+
+

--- a/pkg/commands/internal/devices/init.go
+++ b/pkg/commands/internal/devices/init.go
@@ -59,7 +59,7 @@ func Init(app *cli.Cli) {
 
 	app.Command(
 		"device d",
-		"Commands for dealing with a single device",
+		"Commands for dealing with a single device. The device must be in a workspace to which the user has at least read-only access",
 		func(cmd *cli.Cmd) {
 
 			var deviceSerialStr = cmd.StringArg("ID", "", "The serial of the device")

--- a/pkg/conch/conch.go
+++ b/pkg/conch/conch.go
@@ -32,7 +32,7 @@ type omit bool
 
 const (
 	// MinimumAPIVersion sets the earliest API version that we support.
-	MinimumAPIVersion  = "2.24.0"
+	MinimumAPIVersion  = "2.25.0"
 	BreakingAPIVersion = "3.0.0"
 )
 

--- a/pkg/conch/devices_test.go
+++ b/pkg/conch/devices_test.go
@@ -111,4 +111,13 @@ func TestDevices(t *testing.T) {
 		st.Expect(t, ret, d)
 	})
 
+	t.Run("SubmitDeviceReport", func(t *testing.T) {
+		serial := "test"
+		gock.New(API.BaseURL).Post("/device/" + serial).Reply(400).JSON(ErrApi)
+
+		ret, err := API.SubmitDeviceReport(serial, "")
+		st.Expect(t, err, ErrApiUnpacked)
+		st.Expect(t, ret, conch.ValidationState{})
+	})
+
 }

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -132,17 +132,6 @@ type DeviceLocation struct {
 	TargetHardwareProduct HardwareProductTarget `json:"target_hardware_product"`
 }
 
-type DeviceReportResult struct {
-	Result     ValidationResult `json:"validation_result"`
-	Validation Validation       `json:"validation"`
-}
-
-type DeviceReportState struct {
-	State   ValidationState      `json:"validation_state"`
-	Plan    ValidationPlan       `json:"validation_plan"`
-	Results []DeviceReportResult `json:"results"`
-}
-
 type ExtendedDevice struct {
 	Device
 	IPMI          string                    `json:"ipmi"`


### PR DESCRIPTION
SubmitDeviceReport now returns a ValidationState instead of the previous hybrid structs.

Bumps the API minimum version to v2.25.0

Adds the API tester to the docker based release process.