### PR TITLE
bump the minimum api version to 2.26

### DIFF
--- a/pkg/conch/conch.go
+++ b/pkg/conch/conch.go
@@ -32,7 +32,7 @@ type omit bool
 
 const (
 	// MinimumAPIVersion sets the earliest API version that we support.
-	MinimumAPIVersion  = "2.25.0"
+	MinimumAPIVersion  = "2.26.0"
 	BreakingAPIVersion = "3.0.0"
 )
 


### PR DESCRIPTION
The DeviceLocation changes that were made as part of #281 change our minimum requirement to 2.26