### PR TITLE
API tokens

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,5 @@ FROM scratch
 COPY --from=build /go/src/github.com/joyent/conch-shell/bin/conch /bin/conch
 COPY --from=build /etc/ssl /etc/ssl
 
-ENTRYPOINT [ "/bin/conch", "--no-version-check" ]
+ENTRYPOINT [ "/bin/conch" ]
 CMD ["version"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.12.1-alpine AS build
+# vim: se syn=dockerfile:
+FROM golang:1.12.4-alpine AS build
 ENV CGO_ENABLED 0
 
 RUN apk add --no-cache --update make git perl-utils dep shadow

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,5 +1,5 @@
 # vim: se syn=dockerfile:
-FROM golang:1.12.1-alpine
+FROM golang:1.12.4-alpine
 ENV CGO_ENABLED 0
 
 RUN apk add --no-cache --update make git perl-utils dep shadow

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 VERSION ?= $(shell git describe --tags --abbrev=0 | sed 's/^v//')
 DISABLE_API_VERSION_CHECK ?= 0
+DISABLE_API_TOKEN_CRUD ?= 0
+API_TOKENS_ONLY ?= 0
 
 build: vendor clean test all ## Test and build binaries for local architecture into bin/
 
@@ -49,7 +51,7 @@ RELEASES   := $(foreach bin,$(RELEASE_BINARIES),release/$(bin))
 
 GIT_REV    := $(shell git describe --always --abbrev --dirty --long)
 FLAGS_PATH := github.com/joyent/conch-shell/pkg/util
-LD_FLAGS   := -ldflags="-X $(FLAGS_PATH).Version=$(VERSION) -X $(FLAGS_PATH).GitRev=$(GIT_REV) -X $(FLAGS_PATH).DisableApiVersionCheck=$(DISABLE_API_VERSION_CHECK)"
+LD_FLAGS   := -ldflags="-X $(FLAGS_PATH).Version=$(VERSION) -X $(FLAGS_PATH).GitRev=$(GIT_REV) -X $(FLAGS_PATH).FlagsDisableApiVersionCheck=$(DISABLE_API_VERSION_CHECK) -X $(FLAGS_PATH).FlagsDisableApiTokenCRUD=$(DISABLE_API_TOKEN_CRUD) -X $(FLAGS_PATH).FlagsTokensOnly=$(API_TOKENS_ONLY)"
 BUILD      := CGO_ENABLED=0 go build $(LD_FLAGS) 
 
 ####

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VERSION ?= $(shell git describe --tags --abbrev=0 | sed 's/^v//')
 DISABLE_API_VERSION_CHECK ?= 0
 DISABLE_API_TOKEN_CRUD ?= 0
+DISABLE_ADMIN_FUNCTIONS ?= 0
 API_TOKENS_ONLY ?= 0
 
 build: vendor clean test all ## Test and build binaries for local architecture into bin/
@@ -51,7 +52,7 @@ RELEASES   := $(foreach bin,$(RELEASE_BINARIES),release/$(bin))
 
 GIT_REV    := $(shell git describe --always --abbrev --dirty --long)
 FLAGS_PATH := github.com/joyent/conch-shell/pkg/util
-LD_FLAGS   := -ldflags="-X $(FLAGS_PATH).Version=$(VERSION) -X $(FLAGS_PATH).GitRev=$(GIT_REV) -X $(FLAGS_PATH).FlagsDisableApiVersionCheck=$(DISABLE_API_VERSION_CHECK) -X $(FLAGS_PATH).FlagsDisableApiTokenCRUD=$(DISABLE_API_TOKEN_CRUD) -X $(FLAGS_PATH).FlagsTokensOnly=$(API_TOKENS_ONLY)"
+LD_FLAGS   := -ldflags="-X $(FLAGS_PATH).Version=$(VERSION) -X $(FLAGS_PATH).GitRev=$(GIT_REV) -X $(FLAGS_PATH).FlagsDisableApiVersionCheck=$(DISABLE_API_VERSION_CHECK) -X $(FLAGS_PATH).FlagsDisableApiTokenCRUD=$(DISABLE_API_TOKEN_CRUD) -X $(FLAGS_PATH).FlagsTokensOnly=$(API_TOKENS_ONLY) -X $(FLAGS_PATH).FlagsNoAdmin=$(DISABLE_ADMIN_FUNCTIONS)"
 BUILD      := CGO_ENABLED=0 go build $(LD_FLAGS) 
 
 ####

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ VERSION ?= $(shell git describe --tags --abbrev=0 | sed 's/^v//')
 DISABLE_API_VERSION_CHECK ?= 0
 DISABLE_API_TOKEN_CRUD ?= 0
 DISABLE_ADMIN_FUNCTIONS ?= 0
-API_TOKENS_ONLY ?= 0
 
 build: vendor clean test all ## Test and build binaries for local architecture into bin/
 
@@ -52,7 +51,7 @@ RELEASES   := $(foreach bin,$(RELEASE_BINARIES),release/$(bin))
 
 GIT_REV    := $(shell git describe --always --abbrev --dirty --long)
 FLAGS_PATH := github.com/joyent/conch-shell/pkg/util
-LD_FLAGS   := -ldflags="-X $(FLAGS_PATH).Version=$(VERSION) -X $(FLAGS_PATH).GitRev=$(GIT_REV) -X $(FLAGS_PATH).FlagsDisableApiVersionCheck=$(DISABLE_API_VERSION_CHECK) -X $(FLAGS_PATH).FlagsDisableApiTokenCRUD=$(DISABLE_API_TOKEN_CRUD) -X $(FLAGS_PATH).FlagsTokensOnly=$(API_TOKENS_ONLY) -X $(FLAGS_PATH).FlagsNoAdmin=$(DISABLE_ADMIN_FUNCTIONS)"
+LD_FLAGS   := -ldflags="-X $(FLAGS_PATH).Version=$(VERSION) -X $(FLAGS_PATH).GitRev=$(GIT_REV) -X $(FLAGS_PATH).FlagsDisableApiVersionCheck=$(DISABLE_API_VERSION_CHECK) -X $(FLAGS_PATH).FlagsDisableApiTokenCRUD=$(DISABLE_API_TOKEN_CRUD) -X $(FLAGS_PATH).FlagsNoAdmin=$(DISABLE_ADMIN_FUNCTIONS)"
 BUILD      := CGO_ENABLED=0 go build $(LD_FLAGS) 
 
 ####

--- a/pkg/cmd/conch1/main.go
+++ b/pkg/cmd/conch1/main.go
@@ -126,10 +126,18 @@ func Init() *cli.Cli {
 			if *profileOverride != "" {
 				if prof.Name == *profileOverride {
 					util.ActiveProfile = prof
+					if prof.Token != "" {
+						util.Token = prof.Token
+					}
+
 					break
 				}
 			} else if prof.Active {
 				util.ActiveProfile = prof
+				if prof.Token != "" {
+					util.Token = prof.Token
+				}
+
 				break
 			}
 		}

--- a/pkg/cmd/conch1/main.go
+++ b/pkg/cmd/conch1/main.go
@@ -49,7 +49,7 @@ func Init() *cli.Cli {
 	var (
 		useJSON         = app.BoolOpt("json j", false, "Output JSON")
 		configFile      = app.StringOpt("config c", "~/.conch.json", "Path to config file")
-		noVersion       = app.BoolOpt("no-version-check", false, "Skip Github version check")
+		noVersion       = app.BoolOpt("no-version-check", false, "Does nothing. Included for backwards compatibility.") // TODO(sungo): remove back compat
 		profileOverride = app.StringOpt("profile p", "", "Override the active profile")
 		debugMode       = app.BoolOpt("debug", false, "Debug mode")
 		traceMode       = app.BoolOpt("trace", false, "Trace http requests. Warning: this is super loud")

--- a/pkg/cmd/conch1/main.go
+++ b/pkg/cmd/conch1/main.go
@@ -127,7 +127,7 @@ func Init() *cli.Cli {
 				if prof.Name == *profileOverride {
 					util.ActiveProfile = prof
 					if prof.Token != "" {
-						util.Token = prof.Token
+						util.Token = string(prof.Token)
 					}
 
 					break
@@ -135,7 +135,7 @@ func Init() *cli.Cli {
 			} else if prof.Active {
 				util.ActiveProfile = prof
 				if prof.Token != "" {
-					util.Token = prof.Token
+					util.Token = string(prof.Token)
 				}
 
 				break

--- a/pkg/cmd/conch1/main.go
+++ b/pkg/cmd/conch1/main.go
@@ -41,7 +41,7 @@ func Init() *cli.Cli {
 					conch.MinimumAPIVersion,
 					conch.BreakingAPIVersion,
 				)
-				if util.NoApiVersionCheck {
+				if util.DisableApiVersionCheck() {
 					fmt.Println("\n** API version checking is disabled. Functionality cannot be guaranteed **")
 				}
 			}

--- a/pkg/commands/admin/init.go
+++ b/pkg/commands/admin/init.go
@@ -20,6 +20,10 @@ var UserEmail string
 
 // Init loads up the commands
 func Init(app *cli.Cli) {
+	if util.NoAdmin() {
+		return
+	}
+
 	app.Command(
 		"admin",
 		"Commands for various server-side administrative tasks",

--- a/pkg/commands/admin/init.go
+++ b/pkg/commands/admin/init.go
@@ -65,7 +65,7 @@ func Init(app *cli.Cli) {
 
 					cmd.Command(
 						"revoke",
-						"Revoke the auth tokens for a given user",
+						"Revoke the api tokens and/or logins for a given user",
 						revokeTokens,
 					)
 
@@ -103,6 +103,31 @@ func Init(app *cli.Cli) {
 						"demote",
 						"Demote the user to a regular user",
 						demoteUser,
+					)
+
+					cmd.Command(
+						"tokens",
+						"List the API tokens for a user",
+						listTokens,
+					)
+
+					cmd.Command(
+						"token",
+						"Operate on a user's API tokens",
+						func(cmd *cli.Cmd) {
+							cmd.Command(
+								"get",
+								"Get a user's API token",
+								getToken,
+							)
+
+							cmd.Command(
+								"delete rm",
+								"Delete a user's API token",
+								removeToken,
+							)
+
+						},
 					)
 
 				},

--- a/pkg/commands/admin/main.go
+++ b/pkg/commands/admin/main.go
@@ -240,8 +240,10 @@ func createUser(app *cli.Cmd) {
 }
 
 func resetUserPassword(app *cli.Cmd) {
+	var tokensOpt = app.BoolOpt("revoke-tokens", false, "Also revoke the user's API tokens")
+
 	app.Action = func() {
-		if err := util.API.ResetUserPassword(UserEmail); err != nil {
+		if err := util.API.ResetUserPassword(UserEmail, *tokensOpt); err != nil {
 			util.Bail(err)
 		}
 		if !util.JSON {

--- a/pkg/commands/profile/init.go
+++ b/pkg/commands/profile/init.go
@@ -78,36 +78,6 @@ func Init(app *cli.Cli) {
 					)
 				},
 			)
-
-			cmd.Command(
-				"global",
-				"Change global settings that apply regardless of the profile chosen",
-				func(cmd *cli.Cmd) {
-					cmd.Command(
-						"version-check vc",
-						"Enable/disable version checking",
-						func(cmd *cli.Cmd) {
-							cmd.Command(
-								"status",
-								"See if version checking is enabled or disabled",
-								statusVersionCheck,
-							)
-
-							cmd.Command(
-								"enable",
-								"Enable version checking",
-								enableVersionCheck,
-							)
-
-							cmd.Command(
-								"disable",
-								"Disable version checking",
-								disableVersionCheck,
-							)
-						},
-					)
-				},
-			)
 		},
 	)
 }

--- a/pkg/commands/profile/init.go
+++ b/pkg/commands/profile/init.go
@@ -38,12 +38,6 @@ func Init(app *cli.Cli) {
 			)
 
 			cmd.Command(
-				"refresh",
-				"Refresh the auth token for the active profile",
-				refreshJWT,
-			)
-
-			cmd.Command(
 				"relogin",
 				"Log in again, preserving all other profile data",
 				relogin,

--- a/pkg/commands/profile/init.go
+++ b/pkg/commands/profile/init.go
@@ -68,13 +68,11 @@ func Init(app *cli.Cli) {
 				},
 			)
 
-			if !util.TokensOnly() {
-				cmd.Command(
-					"relogin",
-					"Log in again, preserving all other profile data",
-					relogin,
-				)
-			}
+			cmd.Command(
+				"relogin",
+				"Log in again, preserving all other profile data",
+				relogin,
+			)
 
 			if !util.DisableApiTokenCRUD() {
 				cmd.Command(

--- a/pkg/commands/profile/init.go
+++ b/pkg/commands/profile/init.go
@@ -69,6 +69,12 @@ func Init(app *cli.Cli) {
 			)
 
 			cmd.Command(
+				"upgrade",
+				"Upgrade this profile to use API tokens. This will generate a specific API token for this instance which will *not* be displayed or otherwise accessible",
+				upgradeToToken,
+			)
+
+			cmd.Command(
 				"relogin",
 				"Log in again, preserving all other profile data",
 				relogin,

--- a/pkg/commands/profile/init.go
+++ b/pkg/commands/profile/init.go
@@ -9,6 +9,7 @@ package profile
 
 import (
 	"github.com/jawher/mow.cli"
+	"github.com/joyent/conch-shell/pkg/util"
 )
 
 // Init loads up the profile commands
@@ -38,21 +39,9 @@ func Init(app *cli.Cli) {
 			)
 
 			cmd.Command(
-				"relogin",
-				"Log in again, preserving all other profile data",
-				relogin,
-			)
-
-			cmd.Command(
 				"change-password",
 				"Change the password associated with this profile",
 				changePassword,
-			)
-
-			cmd.Command(
-				"revoke-tokens",
-				"Revoke all auth tokens. User must log in again after this.",
-				revokeJWT,
 			)
 
 			cmd.Command(
@@ -72,6 +61,23 @@ func Init(app *cli.Cli) {
 					)
 				},
 			)
+
+			if !util.TokensOnly() {
+				cmd.Command(
+					"relogin",
+					"Log in again, preserving all other profile data",
+					relogin,
+				)
+			}
+
+			if !util.DisableApiTokenCRUD() {
+				cmd.Command(
+					"revoke-tokens",
+					"Revoke all auth tokens. User must log in again after this.",
+					revokeJWT,
+				)
+			}
+
 		},
 	)
 }

--- a/pkg/commands/profile/init.go
+++ b/pkg/commands/profile/init.go
@@ -59,6 +59,12 @@ func Init(app *cli.Cli) {
 						"Change which profile is active",
 						setActive,
 					)
+
+					cmd.Command(
+						"token",
+						"Change the API token for the active profile. This will convert the profile to token auth if it was previously using login auth",
+						setToken,
+					)
 				},
 			)
 

--- a/pkg/commands/profile/profile.go
+++ b/pkg/commands/profile/profile.go
@@ -7,9 +7,7 @@ package profile
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
-	"time"
 
 	"github.com/Bowery/prompt"
 	"github.com/jawher/mow.cli"
@@ -282,40 +280,6 @@ func setActive(app *cli.Cmd) {
 			fmt.Printf("Done. Config written to %s\n", util.Config.Path)
 		}
 
-	}
-}
-
-func refreshJWT(app *cli.Cmd) {
-	app.Action = func() {
-		util.BuildAPI()
-		if util.ActiveProfile == nil {
-			util.Bail(errors.New("no active profile. Please use 'conch profile' to create or set an active profile"))
-		}
-
-		if err := util.API.VerifyLogin(0, true); err != nil {
-			if util.JSON || err != conch.ErrMustChangePassword {
-				util.Bail(err)
-			}
-			util.InteractiveForcePasswordChange()
-		}
-
-		util.ActiveProfile.JWT = util.API.JWT
-
-		util.WriteConfig(true)
-
-		if util.JSON {
-			util.JSONOut(struct {
-				Expires time.Time `json:"expires"`
-			}{util.API.JWT.Expires})
-
-			return
-		}
-
-		fmt.Printf(
-			"Auth for profile '%s' now expires at %s\n",
-			util.ActiveProfile.Name,
-			util.TimeStr(util.API.JWT.Expires),
-		)
 	}
 }
 

--- a/pkg/commands/profile/profile.go
+++ b/pkg/commands/profile/profile.go
@@ -302,6 +302,7 @@ func revokeJWT(app *cli.Cmd) {
 		if !*forceOpt {
 			return
 		}
+		util.BuildAPI()
 
 		if *allAuth {
 			if err := util.API.RevokeMyTokensAndLogins(); err != nil {

--- a/pkg/commands/profile/profile.go
+++ b/pkg/commands/profile/profile.go
@@ -423,7 +423,7 @@ func setToken(cmd *cli.Cmd) {
 			util.Bail(errors.New("there is no active profile. Please use 'profile set active' to mark a profile as active"))
 		}
 
-		util.ActiveProfile.Token = *tokenArg
+		util.ActiveProfile.Token = config.Token(*tokenArg)
 		util.Token = *tokenArg
 
 		util.ActiveProfile.JWT = conch.ConchJWT{}

--- a/pkg/commands/profile/profile.go
+++ b/pkg/commands/profile/profile.go
@@ -396,3 +396,22 @@ func changePassword(app *cli.Cmd) {
 		util.WriteConfigForce()
 	}
 }
+
+func setToken(cmd *cli.Cmd) {
+	var tokenArg = cmd.StringArg("TOKEN", "", "An API token")
+	cmd.Spec = "TOKEN"
+
+	cmd.Action = func() {
+		if util.ActiveProfile == nil {
+			util.Bail(errors.New("there is no active profile. Please use 'profile set active' to mark a profile as active"))
+		}
+
+		util.ActiveProfile.Token = *tokenArg
+		util.Token = *tokenArg
+
+		util.ActiveProfile.JWT = conch.ConchJWT{}
+
+		util.WriteConfigForce()
+	}
+
+}

--- a/pkg/commands/profile/profile.go
+++ b/pkg/commands/profile/profile.go
@@ -389,7 +389,8 @@ func relogin(app *cli.Cmd) {
 
 func changePassword(app *cli.Cmd) {
 	var (
-		passwordOpt = app.StringOpt("password pass", "", "Account password")
+		passwordOpt  = app.StringOpt("password pass", "", "Account password")
+		revokeTokens = app.BoolOpt("purge-tokens", false, "Also purge API tokens")
 	)
 
 	app.Action = func() {
@@ -400,7 +401,12 @@ func changePassword(app *cli.Cmd) {
 		if password == "" {
 			util.InteractiveForcePasswordChange()
 		} else {
-			if err := util.API.ChangePassword(password); err != nil {
+			err := util.IsPasswordSane(password, nil)
+			if err != nil {
+				util.Bail(err)
+			}
+
+			if err := util.API.ChangeMyPassword(password, *revokeTokens); err != nil {
 				util.Bail(err)
 			}
 		}

--- a/pkg/commands/profile/profile.go
+++ b/pkg/commands/profile/profile.go
@@ -303,7 +303,7 @@ func revokeJWT(app *cli.Cmd) {
 		}
 
 		if *allAuth {
-			if err := util.API.RevokeMyTokens(); err != nil {
+			if err := util.API.RevokeMyTokensAndLogins(); err != nil {
 				util.Bail(err)
 			}
 
@@ -314,7 +314,7 @@ func revokeJWT(app *cli.Cmd) {
 		}
 
 		if *revokeAuth {
-			if err := util.API.RevokeMyAuthTokens(); err != nil {
+			if err := util.API.RevokeMyLogins(); err != nil {
 				util.Bail(err)
 			}
 
@@ -324,7 +324,7 @@ func revokeJWT(app *cli.Cmd) {
 			return
 		}
 		if *tokenAuth {
-			if err := util.API.RevokeMyApiTokens(); err != nil {
+			if err := util.API.RevokeMyTokens(); err != nil {
 				util.Bail(err)
 			}
 

--- a/pkg/commands/profile/profile.go
+++ b/pkg/commands/profile/profile.go
@@ -127,7 +127,7 @@ func newProfile(app *cli.Cmd) {
 		}
 
 		util.Config.Profiles[p.Name] = p
-		util.WriteConfig(true)
+		util.WriteConfigForce()
 
 		if !util.JSON {
 			fmt.Printf("Done. Config written to %s\n", util.Config.Path)
@@ -156,7 +156,7 @@ func deleteProfile(app *cli.Cmd) {
 			}
 		}
 
-		util.WriteConfig(true)
+		util.WriteConfigForce()
 		if !util.JSON {
 			fmt.Printf("Done. Config written to %s\n", util.Config.Path)
 		}
@@ -251,7 +251,7 @@ func setWorkspace(app *cli.Cmd) {
 		util.ActiveProfile.WorkspaceUUID = ws.ID
 		util.ActiveProfile.WorkspaceName = ws.Name
 
-		util.WriteConfig(true)
+		util.WriteConfigForce()
 		if !util.JSON {
 			fmt.Printf("Done. Config written to %s\n", util.Config.Path)
 		}
@@ -280,7 +280,7 @@ func setActive(app *cli.Cmd) {
 			)
 		}
 
-		util.WriteConfig(true)
+		util.WriteConfigForce()
 		if !util.JSON {
 			fmt.Printf("Done. Config written to %s\n", util.Config.Path)
 		}
@@ -369,7 +369,7 @@ func relogin(app *cli.Cmd) {
 
 		util.ActiveProfile.JWT = util.API.JWT
 
-		util.WriteConfig(true)
+		util.WriteConfigForce()
 		if !util.JSON {
 			fmt.Printf("Done. Config written to %s\n", util.Config.Path)
 		}

--- a/pkg/commands/profile/profile.go
+++ b/pkg/commands/profile/profile.go
@@ -368,8 +368,8 @@ func relogin(app *cli.Cmd) {
 		}
 
 		util.ActiveProfile.JWT = util.API.JWT
-
 		util.WriteConfigForce()
+
 		if !util.JSON {
 			fmt.Printf("Done. Config written to %s\n", util.Config.Path)
 		}
@@ -393,5 +393,6 @@ func changePassword(app *cli.Cmd) {
 				util.Bail(err)
 			}
 		}
+		util.WriteConfigForce()
 	}
 }

--- a/pkg/commands/profile/profile.go
+++ b/pkg/commands/profile/profile.go
@@ -7,6 +7,7 @@ package profile
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/Bowery/prompt"
@@ -233,6 +234,10 @@ func setWorkspace(app *cli.Cmd) {
 	}
 
 	app.Action = func() {
+		if util.ActiveProfile == nil {
+			util.Bail(errors.New("there is no active profile. Please use 'profile set active' to mark a profile as active"))
+		}
+
 		workspaceUUID, err := util.MagicWorkspaceID(*workspaceArg)
 		if err != nil {
 			util.Bail(err)
@@ -337,6 +342,10 @@ func relogin(app *cli.Cmd) {
 	)
 
 	app.Action = func() {
+		if util.ActiveProfile == nil {
+			util.Bail(errors.New("there is no active profile. Please use 'profile set active' to mark a profile as active"))
+		}
+
 		util.BuildAPI()
 
 		password := *passwordOpt

--- a/pkg/commands/profile/profile.go
+++ b/pkg/commands/profile/profile.go
@@ -202,7 +202,8 @@ func listProfiles(app *cli.Cmd) {
 					workspaceName = prof.WorkspaceName
 				}
 			}
-			expires := "[relogin]"
+
+			expires := ""
 			if !prof.JWT.Expires.IsZero() {
 				expires = util.TimeStr(prof.JWT.Expires)
 			}

--- a/pkg/commands/profile/profile.go
+++ b/pkg/commands/profile/profile.go
@@ -128,7 +128,8 @@ func newProfile(app *cli.Cmd) {
 		}
 
 		util.Config.Profiles[p.Name] = p
-		util.WriteConfig()
+		util.WriteConfig(true)
+
 		if !util.JSON {
 			fmt.Printf("Done. Config written to %s\n", util.Config.Path)
 		}
@@ -156,7 +157,7 @@ func deleteProfile(app *cli.Cmd) {
 			}
 		}
 
-		util.WriteConfig()
+		util.WriteConfig(true)
 		if !util.JSON {
 			fmt.Printf("Done. Config written to %s\n", util.Config.Path)
 		}
@@ -190,7 +191,11 @@ func listProfiles(app *cli.Cmd) {
 		for _, prof := range util.Config.Profiles {
 			active := ""
 			if prof.Active {
-				active = "*"
+				if util.IgnoreConfig {
+					active = "*?"
+				} else {
+					active = "*"
+				}
 			}
 			workspaceName := ""
 			if !uuid.Equal(prof.WorkspaceUUID, uuid.UUID{}) {
@@ -213,6 +218,9 @@ func listProfiles(app *cli.Cmd) {
 			})
 		}
 		table.Render()
+		if util.IgnoreConfig {
+			fmt.Println("\n? The active profile has been overridden by the use of a token")
+		}
 	}
 }
 
@@ -240,7 +248,7 @@ func setWorkspace(app *cli.Cmd) {
 		util.ActiveProfile.WorkspaceUUID = ws.ID
 		util.ActiveProfile.WorkspaceName = ws.Name
 
-		util.WriteConfig()
+		util.WriteConfig(true)
 		if !util.JSON {
 			fmt.Printf("Done. Config written to %s\n", util.Config.Path)
 		}
@@ -269,7 +277,7 @@ func setActive(app *cli.Cmd) {
 			)
 		}
 
-		util.WriteConfig()
+		util.WriteConfig(true)
 		if !util.JSON {
 			fmt.Printf("Done. Config written to %s\n", util.Config.Path)
 		}
@@ -293,7 +301,7 @@ func refreshJWT(app *cli.Cmd) {
 
 		util.ActiveProfile.JWT = util.API.JWT
 
-		util.WriteConfig()
+		util.WriteConfig(true)
 
 		if util.JSON {
 			util.JSONOut(struct {
@@ -358,7 +366,7 @@ func relogin(app *cli.Cmd) {
 
 		util.ActiveProfile.JWT = util.API.JWT
 
-		util.WriteConfig()
+		util.WriteConfig(true)
 		if !util.JSON {
 			fmt.Printf("Done. Config written to %s\n", util.Config.Path)
 		}

--- a/pkg/commands/profile/profile.go
+++ b/pkg/commands/profile/profile.go
@@ -384,27 +384,3 @@ func changePassword(app *cli.Cmd) {
 		}
 	}
 }
-
-func enableVersionCheck(app *cli.Cmd) {
-	app.Action = func() {
-		util.Config.SkipVersionCheck = false
-		util.WriteConfig()
-	}
-}
-
-func disableVersionCheck(app *cli.Cmd) {
-	app.Action = func() {
-		util.Config.SkipVersionCheck = true
-		util.WriteConfig()
-	}
-}
-
-func statusVersionCheck(app *cli.Cmd) {
-	app.Action = func() {
-		if util.Config.SkipVersionCheck {
-			fmt.Println("disabled")
-		} else {
-			fmt.Println("enabled")
-		}
-	}
-}

--- a/pkg/commands/user/init.go
+++ b/pkg/commands/user/init.go
@@ -72,6 +72,42 @@ func Init(app *cli.Cli) {
 					)
 				},
 			)
+
+			// The biggest use case for disabling these functions is security,
+			// particularly when it comes to edge automation. It's probably a
+			// bad idea for some automation on a random server to be able to
+			// create and remove tokens.
+			if !util.DisableApiTokenCRUD() {
+				cmd.Command(
+					"tokens",
+					"List API tokens",
+					listTokens,
+				)
+
+				cmd.Command(
+					"token",
+					"Operate on a single token",
+					func(cmd *cli.Cmd) {
+						cmd.Command(
+							"remove del rm",
+							"Remove an API token",
+							removeToken,
+						)
+
+						cmd.Command(
+							"create",
+							"Create an API token",
+							createToken,
+						)
+
+						cmd.Command(
+							"get",
+							"See information about a single API token",
+							getToken,
+						)
+					},
+				)
+			}
 		},
 	)
 }

--- a/pkg/commands/user/user.go
+++ b/pkg/commands/user/user.go
@@ -151,7 +151,7 @@ func listTokens(app *cli.Cmd) {
 	app.Before = util.BuildAPIAndVerifyLogin
 
 	app.Action = func() {
-		tokens, err := util.API.GetMyApiTokens()
+		tokens, err := util.API.GetMyTokens()
 		if err != nil {
 			util.Bail(err)
 		}

--- a/pkg/conch/auth.go
+++ b/pkg/conch/auth.go
@@ -55,7 +55,20 @@ func (c *Conch) RevokeUserApiTokens(user string) error {
 	return c.post("/user/"+uPart+"/revoke?api_only=1", nil, nil)
 }
 
-// VerifyLogin determines if the user's session data is still valid.
+func (c *Conch) VerifyToken() (bool, error) {
+	if c.Token == "" {
+		return false, ErrBadInput
+	}
+
+	_, err := c.GetUserSettings()
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// VerifyJwtLogin determines if the user's JWT auth data is still valid.
 //
 // One can pass in an integer value, representing when to force a token
 // refresh, based on the number of seconds left until expiry. Pass in 0 to
@@ -64,7 +77,7 @@ func (c *Conch) RevokeUserApiTokens(user string) error {
 // If the second parameter is true, a JWT refresh is forced, regardless of any
 // other parameters.
 //
-func (c *Conch) VerifyLogin(refreshTime int, forceJWT bool) error {
+func (c *Conch) VerifyJwtLogin(refreshTime int, forceJWT bool) error {
 	u, _ := url.Parse(c.BaseURL)
 
 	if !forceJWT {

--- a/pkg/conch/auth.go
+++ b/pkg/conch/auth.go
@@ -54,7 +54,8 @@ func (c *Conch) RevokeUserTokens(user string) error {
 }
 
 func (c *Conch) GetUserToken(user string, name string) (u UserToken, err error) {
-	return u, c.get("/user/email="+user+"/token/"+name, &u)
+	escapedName := url.PathEscape(name)
+	return u, c.get("/user/email="+user+"/token/"+escapedName, &u)
 }
 
 func (c *Conch) GetUserTokens(user string) (UserTokens, error) {
@@ -63,7 +64,8 @@ func (c *Conch) GetUserTokens(user string) (UserTokens, error) {
 }
 
 func (c *Conch) DeleteUserToken(user string, name string) error {
-	return c.httpDelete("/user/email=" + user + "/token/" + name)
+	escapedName := url.PathEscape(name)
+	return c.httpDelete("/user/email=" + user + "/token/" + escapedName)
 }
 
 func (c *Conch) VerifyToken() (bool, error) {

--- a/pkg/conch/auth.go
+++ b/pkg/conch/auth.go
@@ -17,9 +17,7 @@ import (
 	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
-// RevokeUserTokens revokes all auth and api tokens for a the given user. This
-// action is typically limited server-side to admins.
-func (c *Conch) RevokeUserTokens(user string) error {
+func (c *Conch) RevokeUserTokensAndLogins(user string) error {
 	var uPart string
 	_, err := uuid.FromString(user)
 	if err == nil {
@@ -31,7 +29,7 @@ func (c *Conch) RevokeUserTokens(user string) error {
 	return c.post("/user/"+uPart+"/revoke", nil, nil)
 }
 
-func (c *Conch) RevokeUserAuthTokens(user string) error {
+func (c *Conch) RevokeUserLogins(user string) error {
 	var uPart string
 	_, err := uuid.FromString(user)
 	if err == nil {
@@ -43,7 +41,7 @@ func (c *Conch) RevokeUserAuthTokens(user string) error {
 	return c.post("/user/"+uPart+"/revoke?auth_only=1", nil, nil)
 }
 
-func (c *Conch) RevokeUserApiTokens(user string) error {
+func (c *Conch) RevokeUserTokens(user string) error {
 	var uPart string
 	_, err := uuid.FromString(user)
 	if err == nil {
@@ -53,6 +51,19 @@ func (c *Conch) RevokeUserApiTokens(user string) error {
 	}
 
 	return c.post("/user/"+uPart+"/revoke?api_only=1", nil, nil)
+}
+
+func (c *Conch) GetUserToken(user string, name string) (u UserToken, err error) {
+	return u, c.get("/user/email="+user+"/token/"+name, &u)
+}
+
+func (c *Conch) GetUserTokens(user string) (UserTokens, error) {
+	u := make(UserTokens, 0)
+	return u, c.get("/user/email="+user+"/token", &u)
+}
+
+func (c *Conch) DeleteUserToken(user string, name string) error {
+	return c.httpDelete("/user/email=" + user + "/token/" + name)
 }
 
 func (c *Conch) VerifyToken() (bool, error) {

--- a/pkg/conch/conch.go
+++ b/pkg/conch/conch.go
@@ -32,7 +32,7 @@ type omit bool
 
 const (
 	// MinimumAPIVersion sets the earliest API version that we support.
-	MinimumAPIVersion  = "2.26.0"
+	MinimumAPIVersion  = "2.27.0"
 	BreakingAPIVersion = "3.0.0"
 )
 

--- a/pkg/conch/sling.go
+++ b/pkg/conch/sling.go
@@ -86,10 +86,12 @@ func (c *Conch) sling() *sling.Sling {
 		Base(c.BaseURL).
 		Set("User-Agent", c.UA)
 
-	// BUG(sungo) This is mostly for the config back compat code. Once that's
-	// gone, we can probably just check the expires value
-	if (c.JWT.Token != "") && (c.JWT.Signature != "") {
-		s = s.Set("Authorization", "Bearer "+c.JWT.FullToken())
+	if c.Token != "" {
+		s = s.Set("Authorization", "Bearer "+c.Token)
+	} else {
+		if (c.JWT.Token != "") && (c.JWT.Signature != "") {
+			s = s.Set("Authorization", "Bearer "+c.JWT.FullToken())
+		}
 	}
 
 	return s

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -620,3 +620,36 @@ The payload looks like:
 Where '47' is the rack unit start for the device
 */
 type WorkspaceRackLayoutAssignments map[string]int
+
+// corresponds to conch.git/json-schema/input.yaml;NewUserToken
+type CreateNewUserToken struct {
+	Name string `json:"name"`
+}
+
+// corresponds to conch.git/json-schema/response.yaml;UserToken
+type UserToken struct {
+	Name     string    `json:"name"`
+	Created  time.Time `json:"created"`
+	LastUsed time.Time `json:"last_used,omitempty"`
+	Expires  time.Time `json:"expires"`
+}
+
+type UserTokens []UserToken
+
+func (u UserTokens) Len() int {
+	return len(u)
+}
+
+func (u UserTokens) Swap(i, j int) {
+	u[i], u[j] = u[j], u[i]
+}
+
+func (u UserTokens) Less(i, j int) bool {
+	return u[i].Name < u[j].Name
+}
+
+// corresponds to conch.git/json-schema/response.yaml;NewUserToken
+type NewUserToken struct {
+	UserToken
+	Token string `json:"token"`
+}

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -31,6 +31,7 @@ type Conch struct {
 	Debug   bool
 	Trace   bool
 	JWT     ConchJWT
+	Token   string // replacement for JWT
 
 	HTTPClient *http.Client
 	CookieJar  *cookiejar.Jar

--- a/pkg/conch/user.go
+++ b/pkg/conch/user.go
@@ -8,6 +8,7 @@ package conch
 
 import (
 	"fmt"
+	"net/url"
 
 	uuid "gopkg.in/satori/go.uuid.v1"
 )
@@ -18,7 +19,8 @@ func (c *Conch) GetMyTokens() (UserTokens, error) {
 }
 
 func (c *Conch) GetMyToken(name string) (u UserToken, err error) {
-	return u, c.get("/user/me/token/"+name, &u)
+	escapedName := url.PathEscape(name)
+	return u, c.get("/user/me/token/"+escapedName, &u)
 }
 
 func (c *Conch) CreateMyToken(name string) (u NewUserToken, err error) {
@@ -30,7 +32,8 @@ func (c *Conch) CreateMyToken(name string) (u NewUserToken, err error) {
 }
 
 func (c *Conch) DeleteMyToken(name string) error {
-	return c.httpDelete("/user/me/token/" + name)
+	escapedName := url.PathEscape(name)
+	return c.httpDelete("/user/me/token/" + escapedName)
 }
 
 func (c *Conch) RevokeMyLogins() error {

--- a/pkg/conch/user_test.go
+++ b/pkg/conch/user_test.go
@@ -132,31 +132,25 @@ func TestUserErrors(t *testing.T) {
 		st.Expect(t, err, ErrApiUnpacked)
 	})
 
-	t.Run("RevokeMyAuthTokens", func(t *testing.T) {
+	t.Run("RevokeMyLogins", func(t *testing.T) {
 		gock.New(API.BaseURL).Post("/user/me/revoke").
 			MatchParam("auth_only", "1").Reply(400).JSON(ErrApi)
 
-		err := API.RevokeMyAuthTokens()
-		st.Expect(t, err, ErrApiUnpacked)
-	})
-
-	t.Run("RevokeMyApiTokens", func(t *testing.T) {
-		gock.New(API.BaseURL).Post("/user/me/revoke").
-			MatchParam("api_only", "1").Reply(400).JSON(ErrApi)
-
-		err := API.RevokeMyApiTokens()
+		err := API.RevokeMyLogins()
 		st.Expect(t, err, ErrApiUnpacked)
 	})
 
 	t.Run("RevokeMyTokens", func(t *testing.T) {
-		gock.New(API.BaseURL).Post("/user/me/revoke").Reply(400).JSON(ErrApi)
+		gock.New(API.BaseURL).Post("/user/me/revoke").
+			MatchParam("api_only", "1").Reply(400).JSON(ErrApi)
+
 		err := API.RevokeMyTokens()
 		st.Expect(t, err, ErrApiUnpacked)
 	})
 
-	t.Run("RevokeOwnTokens", func(t *testing.T) {
+	t.Run("RevokeMyTokensAndLogins", func(t *testing.T) {
 		gock.New(API.BaseURL).Post("/user/me/revoke").Reply(400).JSON(ErrApi)
-		err := API.RevokeOwnTokens()
+		err := API.RevokeMyTokensAndLogins()
 		st.Expect(t, err, ErrApiUnpacked)
 	})
 

--- a/pkg/conch/user_test.go
+++ b/pkg/conch/user_test.go
@@ -78,9 +78,18 @@ func TestUserErrors(t *testing.T) {
 	})
 
 	t.Run("ResetUserPassword", func(t *testing.T) {
-		gock.New(API.BaseURL).Delete("/user/email=foo@bar.bat").Reply(400).JSON(ErrApi)
-		err := API.ResetUserPassword("foo@bar.bat")
+		gock.New(API.BaseURL).Delete("/user/email=foo@bar.bat").
+			MatchParam("clear_tokens", "login_only").Reply(400).JSON(ErrApi)
+
+		err := API.ResetUserPassword("foo@bar.bat", false)
 		st.Expect(t, err, ErrApiUnpacked)
+
+		gock.New(API.BaseURL).Delete("/user/email=foo@bar.bat").
+			MatchParam("clear_tokens", "all").Reply(400).JSON(ErrApi)
+
+		err = API.ResetUserPassword("foo@bar.bat", true)
+		st.Expect(t, err, ErrApiUnpacked)
+
 	})
 
 	t.Run("GetAllUsers", func(t *testing.T) {
@@ -154,16 +163,17 @@ func TestUserErrors(t *testing.T) {
 		st.Expect(t, err, ErrApiUnpacked)
 	})
 
-	t.Run("ChangePassword", func(t *testing.T) {
-		gock.New(API.BaseURL).Post("/user/me/password").Reply(400).JSON(ErrApi)
-		err := API.ChangePassword("pants")
-		st.Expect(t, err, ErrApiUnpacked)
-	})
-
 	t.Run("ChangeMyPassword", func(t *testing.T) {
-		gock.New(API.BaseURL).Post("/user/me/password").Reply(400).JSON(ErrApi)
-		err := API.ChangeMyPassword("pants")
+		gock.New(API.BaseURL).Post("/user/me/password").
+			MatchParam("clear_tokens", "login_only").Reply(400).JSON(ErrApi)
+		err := API.ChangeMyPassword("pants", false)
 		st.Expect(t, err, ErrApiUnpacked)
+
+		gock.New(API.BaseURL).Post("/user/me/password").
+			MatchParam("clear_tokens", "all").Reply(400).JSON(ErrApi)
+		err = API.ChangeMyPassword("pants", true)
+		st.Expect(t, err, ErrApiUnpacked)
+
 	})
 
 }

--- a/pkg/conch/user_test.go
+++ b/pkg/conch/user_test.go
@@ -98,4 +98,78 @@ func TestUserErrors(t *testing.T) {
 		st.Expect(t, err, ErrApiUnpacked)
 	})
 
+	t.Run("GetMyTokens", func(t *testing.T) {
+		gock.New(API.BaseURL).Get("/user/me/token").Reply(400).JSON(ErrApi)
+		tokens, err := API.GetMyTokens()
+		st.Expect(t, tokens, make(conch.UserTokens, 0))
+		st.Expect(t, err, ErrApiUnpacked)
+
+	})
+
+	t.Run("GetMyToken", func(t *testing.T) {
+		tokenName := "token_test"
+		gock.New(API.BaseURL).Get("/user/me/token/" + tokenName).Reply(400).JSON(ErrApi)
+
+		token, err := API.GetMyToken(tokenName)
+		st.Expect(t, token, conch.UserToken{})
+		st.Expect(t, err, ErrApiUnpacked)
+	})
+
+	t.Run("CreateMyToken", func(t *testing.T) {
+		tokenName := "token_test"
+		gock.New(API.BaseURL).Post("/user/me/token").Reply(400).JSON(ErrApi)
+
+		token, err := API.CreateMyToken(tokenName)
+		st.Expect(t, token, conch.NewUserToken{})
+		st.Expect(t, err, ErrApiUnpacked)
+	})
+
+	t.Run("DeleteMyToken", func(t *testing.T) {
+		tokenName := "token_test"
+		gock.New(API.BaseURL).Delete("/user/me/token/" + tokenName).Reply(400).JSON(ErrApi)
+
+		err := API.DeleteMyToken(tokenName)
+		st.Expect(t, err, ErrApiUnpacked)
+	})
+
+	t.Run("RevokeMyAuthTokens", func(t *testing.T) {
+		gock.New(API.BaseURL).Post("/user/me/revoke").
+			MatchParam("auth_only", "1").Reply(400).JSON(ErrApi)
+
+		err := API.RevokeMyAuthTokens()
+		st.Expect(t, err, ErrApiUnpacked)
+	})
+
+	t.Run("RevokeMyApiTokens", func(t *testing.T) {
+		gock.New(API.BaseURL).Post("/user/me/revoke").
+			MatchParam("api_only", "1").Reply(400).JSON(ErrApi)
+
+		err := API.RevokeMyApiTokens()
+		st.Expect(t, err, ErrApiUnpacked)
+	})
+
+	t.Run("RevokeMyTokens", func(t *testing.T) {
+		gock.New(API.BaseURL).Post("/user/me/revoke").Reply(400).JSON(ErrApi)
+		err := API.RevokeMyTokens()
+		st.Expect(t, err, ErrApiUnpacked)
+	})
+
+	t.Run("RevokeOwnTokens", func(t *testing.T) {
+		gock.New(API.BaseURL).Post("/user/me/revoke").Reply(400).JSON(ErrApi)
+		err := API.RevokeOwnTokens()
+		st.Expect(t, err, ErrApiUnpacked)
+	})
+
+	t.Run("ChangePassword", func(t *testing.T) {
+		gock.New(API.BaseURL).Post("/user/me/password").Reply(400).JSON(ErrApi)
+		err := API.ChangePassword("pants")
+		st.Expect(t, err, ErrApiUnpacked)
+	})
+
+	t.Run("ChangeMyPassword", func(t *testing.T) {
+		gock.New(API.BaseURL).Post("/user/me/password").Reply(400).JSON(ErrApi)
+		err := API.ChangeMyPassword("pants")
+		st.Expect(t, err, ErrApiUnpacked)
+	})
+
 }

--- a/pkg/config/main.go
+++ b/pkg/config/main.go
@@ -20,6 +20,11 @@ import (
 	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
+const (
+	ProductionURL = "https://conch.joyent.us"
+	StagingURL    = "https://staging.conch.joyent.us"
+)
+
 // ErrConfigNoPath is issued when a file operation is attempted on a
 // ConchConfig that lacks a path
 var ErrConfigNoPath = errors.New("no path found in config data")
@@ -27,9 +32,8 @@ var ErrConfigNoPath = errors.New("no path found in config data")
 // ConchConfig represents the configuration information for the shell, mostly
 // just a profile list
 type ConchConfig struct {
-	Path             string                   `json:"path"`
-	SkipVersionCheck bool                     `json:"skip_version_check"`
-	Profiles         map[string]*ConchProfile `json:"profiles"`
+	Path     string                   `json:"path"`
+	Profiles map[string]*ConchProfile `json:"profiles"`
 }
 
 // ConchProfile is an individual environment, consisting of login data, API
@@ -50,9 +54,8 @@ type ConchProfile struct {
 // "http://localhost:5001".
 func New() (c *ConchConfig) {
 	c = &ConchConfig{
-		Path:             "~/.conch.json",
-		Profiles:         make(map[string]*ConchProfile),
-		SkipVersionCheck: false,
+		Path:     "~/.conch.json",
+		Profiles: make(map[string]*ConchProfile),
 	}
 
 	return c
@@ -65,16 +68,15 @@ func NewFromJSON(j string) (c *ConchConfig, err error) {
 	// compatbility. Need to give it a release or two in production before
 	// removing this grossness.
 	type conchProfileTransition struct {
-		Name             string    `json:"name"`
-		User             string    `json:"user"`
-		Session          string    `json:"session,omitempty"`
-		WorkspaceUUID    uuid.UUID `json:"workspace_id"`
-		WorkspaceName    string    `json:"workspace_name"`
-		BaseURL          string    `json:"api_url"`
-		Active           bool      `json:"active"`
-		JWT              string    `json:"jwt"`
-		Expires          int64     `json:"expires,omitempty"`
-		SkipVersionCheck bool      `json:"skip_version_check"`
+		Name          string    `json:"name"`
+		User          string    `json:"user"`
+		Session       string    `json:"session,omitempty"`
+		WorkspaceUUID uuid.UUID `json:"workspace_id"`
+		WorkspaceName string    `json:"workspace_name"`
+		BaseURL       string    `json:"api_url"`
+		Active        bool      `json:"active"`
+		JWT           string    `json:"jwt"`
+		Expires       int64     `json:"expires,omitempty"`
 	}
 
 	type conchConfigTransition struct {

--- a/pkg/config/obfuscate/main.go
+++ b/pkg/config/obfuscate/main.go
@@ -1,0 +1,74 @@
+// Copyright Joyent, Inc.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package obfuscate
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"io"
+)
+
+func Obfuscate(data string, key string) (string, error) {
+
+	// We need a 32 byte key which sha256 is happy to give us
+	sum := sha256.Sum256([]byte(key))
+	c, err := aes.NewCipher(sum[:])
+
+	if err != nil {
+		return "", err
+	}
+
+	gcm, err := cipher.NewGCM(c)
+	if err != nil {
+		return "", err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+
+	b := gcm.Seal(nonce, nonce, []byte(data), nil)
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func Deobfuscate(text string, key string) (string, error) {
+
+	data, err := base64.RawURLEncoding.DecodeString(text)
+	if err != nil {
+		return "", err
+	}
+
+	sum := sha256.Sum256([]byte(key))
+	c, err := aes.NewCipher(sum[:])
+	if err != nil {
+		return "", err
+	}
+
+	gcm, err := cipher.NewGCM(c)
+	if err != nil {
+		return "", err
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(data) < nonceSize {
+		return "", errors.New("ciphertext smaller than nonce")
+	}
+
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+
+	plain, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -59,20 +59,29 @@ var (
 
 // These variables are provided by the build environment
 var (
-	Version                string
-	GitRev                 string
-	DisableApiVersionCheck string
+	Version                     string
+	GitRev                      string
+	FlagsDisableApiVersionCheck string
+	FlagsDisableApiTokenCRUD    string
+	FlagsTokensOnly             string
 
 	SemVersion semver.Version
 )
 
-var NoApiVersionCheck bool
+func DisableApiVersionCheck() bool {
+	return FlagsDisableApiVersionCheck == "0"
+}
+
+func DisableApiTokenCRUD() bool {
+	return FlagsDisableApiTokenCRUD == "0"
+}
+
+func TokensOnly() bool {
+	return FlagsTokensOnly == "0"
+}
 
 func init() {
 	SemVersion = CleanVersion(Version)
-	if DisableApiVersionCheck == "1" {
-		NoApiVersionCheck = true
-	}
 }
 
 // DateFormat should be used in date formatting calls to ensure uniformity of
@@ -150,7 +159,7 @@ func BuildAPI() {
 		Bail(err)
 	}
 
-	if NoApiVersionCheck {
+	if DisableApiVersionCheck() {
 		return
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -70,19 +70,19 @@ var (
 )
 
 func DisableApiVersionCheck() bool {
-	return FlagsDisableApiVersionCheck == "0"
+	return FlagsDisableApiVersionCheck != "0"
 }
 
 func DisableApiTokenCRUD() bool {
-	return FlagsDisableApiTokenCRUD == "0"
+	return FlagsDisableApiTokenCRUD != "0"
 }
 
 func TokensOnly() bool {
-	return FlagsTokensOnly == "0"
+	return FlagsTokensOnly != "0"
 }
 
 func NoAdmin() bool {
-	return FlagsNoAdmin == "0"
+	return FlagsNoAdmin != "0"
 }
 
 func init() {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -408,6 +408,28 @@ func DDP(v interface{}) {
 	)
 }
 
+func GithubReleaseCheck() {
+	gh, err := LatestGithubRelease()
+	if (err != nil) && (err != ErrNoGithubRelease) {
+		Bail(err)
+	}
+	if gh.Upgrade {
+		os.Stderr.WriteString(fmt.Sprintf(`
+A new release is available! You have v%s but %s is available.
+The changelog can be viewed via 'conch update changelog'
+
+You can obtain the new release by:
+* Running 'conch update self', which will attempt to overwrite the current application
+* Manually download the new release at %s
+
+`,
+			Version,
+			gh.TagName,
+			gh.URL,
+		))
+	}
+}
+
 func init() {
 	spew.Config = spew.ConfigState{
 		Indent:                  "    ",

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -439,7 +439,7 @@ func InteractiveForcePasswordChange() {
 		}
 
 	}
-	if err := API.ChangePassword(password); err != nil {
+	if err := API.ChangeMyPassword(password, false); err != nil {
 		Bail(err)
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -103,17 +103,18 @@ func TimeStr(t time.Time) string {
 func BuildAPIAndVerifyLogin() {
 	BuildAPI()
 
-	if IgnoreConfig {
-		return
-	}
-
 	if Token != "" {
+		ok, err := API.VerifyToken()
+		if !ok {
+			Bail(err)
+		}
 		return
 	}
 
-	if err := API.VerifyLogin(RefreshTokenTime, false); err != nil {
+	if err := API.VerifyJwtLogin(RefreshTokenTime, false); err != nil {
 		Bail(err)
 	}
+
 	ActiveProfile.JWT = API.JWT
 	WriteConfig()
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -65,7 +65,6 @@ var (
 
 	FlagsDisableApiVersionCheck string // Used in shell development
 	FlagsDisableApiTokenCRUD    string // Useful for preventing automations from creating and deleting tokens
-	FlagsTokensOnly             string // Useful for finally killing password auth
 	FlagsNoAdmin                string // Useful for preventing automations from accessing admin commands
 
 )
@@ -76,10 +75,6 @@ func DisableApiVersionCheck() bool {
 
 func DisableApiTokenCRUD() bool {
 	return FlagsDisableApiTokenCRUD != "0"
-}
-
-func TokensOnly() bool {
-	return FlagsTokensOnly != "0"
 }
 
 func NoAdmin() bool {
@@ -109,10 +104,6 @@ func BuildAPIAndVerifyLogin() {
 	BuildAPI()
 
 	if IgnoreConfig {
-		return
-	}
-
-	if TokensOnly() {
 		return
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -115,17 +115,21 @@ func BuildAPIAndVerifyLogin() {
 		Bail(err)
 	}
 	ActiveProfile.JWT = API.JWT
-	WriteConfig(false)
+	WriteConfig()
 }
 
 // WriteConfig serializes the Config struct to disk
-func WriteConfig(force bool) {
-	if !force {
-		if IgnoreConfig {
-			return
-		}
+func WriteConfig() {
+	if IgnoreConfig {
+		return
 	}
 
+	if err := Config.SerializeToFile(Config.Path); err != nil {
+		Bail(err)
+	}
+}
+
+func WriteConfigForce() {
 	if err := Config.SerializeToFile(Config.Path); err != nil {
 		Bail(err)
 	}
@@ -444,7 +448,7 @@ func InteractiveForcePasswordChange() {
 
 	ActiveProfile.JWT = API.JWT
 
-	WriteConfig(false)
+	WriteConfig()
 }
 
 // DDP pretty prints a structure to stderr. "Deep Data Printer"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -111,6 +111,14 @@ func BuildAPIAndVerifyLogin() {
 		return
 	}
 
+	if TokensOnly() {
+		return
+	}
+
+	if Token != "" {
+		return
+	}
+
 	if err := API.VerifyLogin(RefreshTokenTime, false); err != nil {
 		Bail(err)
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -64,6 +64,7 @@ var (
 	FlagsDisableApiVersionCheck string
 	FlagsDisableApiTokenCRUD    string
 	FlagsTokensOnly             string
+	FlagsNoAdmin                string
 
 	SemVersion semver.Version
 )
@@ -78,6 +79,10 @@ func DisableApiTokenCRUD() bool {
 
 func TokensOnly() bool {
 	return FlagsTokensOnly == "0"
+}
+
+func NoAdmin() bool {
+	return FlagsNoAdmin == "0"
 }
 
 func init() {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -448,7 +448,7 @@ func InteractiveForcePasswordChange() {
 
 	ActiveProfile.JWT = API.JWT
 
-	WriteConfig()
+	WriteConfigForce()
 }
 
 // DDP pretty prints a structure to stderr. "Deep Data Printer"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -59,14 +59,15 @@ var (
 
 // These variables are provided by the build environment
 var (
-	Version                     string
-	GitRev                      string
-	FlagsDisableApiVersionCheck string
-	FlagsDisableApiTokenCRUD    string
-	FlagsTokensOnly             string
-	FlagsNoAdmin                string
-
+	Version    string
+	GitRev     string
 	SemVersion semver.Version
+
+	FlagsDisableApiVersionCheck string // Used in shell development
+	FlagsDisableApiTokenCRUD    string // Useful for preventing automations from creating and deleting tokens
+	FlagsTokensOnly             string // Useful for finally killing password auth
+	FlagsNoAdmin                string // Useful for preventing automations from accessing admin commands
+
 )
 
 func DisableApiVersionCheck() bool {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -154,7 +154,7 @@ func BuildAPI() {
 		API = &conch.Conch{
 			BaseURL: ActiveProfile.BaseURL,
 			JWT:     ActiveProfile.JWT,
-			Token:   ActiveProfile.Token,
+			Token:   string(ActiveProfile.Token),
 			Debug:   Debug,
 			Trace:   Trace,
 		}


### PR DESCRIPTION
Introduces support for API tokens. Closes #287. Closes #286.

Two main states are supported:
* The user can upgrade their profiles to token auth.
* By specifying the `CONCH_TOKEN` environment variable, the user can operate entirely without a config file. Also, this will ignore any local file if it exists.

Tokens are obfuscated in the config file, preventing them from being copy and pasted from the config itself.

Another notable change is that it is no longer possible for users to opt out of the shell version check. This is to increase awareness of new versions and hopefully get users to upgrade. 

- - - 

New environment variables:
* `CONCH_TOKEN` - specify the API token
* `CONCH_ENV` - `production`, `staging`, or `development` (defaults to `production`)
* `CONCH_URL` - if `CONCH_ENV=development`, specifies the API's URL

Commands Added:
* Users
  * `profile set token :token` - converts a profile to token auth, using the provided token
  * `profile upgrade` - converts a profile to token auth by auto-generating a token which is never shared to the user
  * `user tokens` - list all API tokens
  * `user token create :name` - create a token with the given name, displaying the token value
  * `user token get :name` - get basic data (including last used time) about a token. Does *not* show the token value
  * `user token rm :name` - remove a token by name

* Admins
  * `admin user :id tokens` - List a user's API tokens
  * `admin user :id token get :name` - Get a user's API token by name. Does *not* show the token value
  * `admin user :id token rm :name` - Remove a user's token by name

Commands Changed:
* In `profile create`, a user can specify `--token` to create a new profile with a token, rather than user/password authentication.
* In `admin user :id revoke` and `user profile revoke-tokens`, the user can choose to revoke logins, API tokens, or both.
* In `admin user :id reset` and `profile change-password`, all of the user's logins will be revoked, forcing the user to log in both the the shell and the web UI.

Version Check Changes:
* It is no longer possible to skip the shell version check. The upgrade message is printed to stderr, however, so users can run `conch 2>/dev/null` but they will then miss all other error messages. This change was made because the API is changing rapidly. Running an old version of the shell is increasingly problematic and users need to be on arapid upgrade cycle.
* `conch --no-version-check` has been rendered non-operable. The parameter is supported for backwards compatibility but displays an error.

Build:
* Go upgraded to 1.12.4 (from 1.12.1)
* Three new makefile variables are supported:
  * `DISABLE_API_TOKEN_CRUD` - removes all commands for creating or modifying API tokens
  * `DISABLE_ADMIN_FUNCTIONS` - disables the `admin` command tree
  * `TOKEN_OBFUSCATION_KEY` - used in the obfuscation of tokens in the config file. While a default is provided, it is *strongly* recommended that this be customized in the build environment. *NOTE*: If this value is ever changed, it will render the tokens in user configs completely unusable.
.
