### PR TITLE
conch/uuid library that wraps gofrs/uuid

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,6 @@
 
 
 [[projects]]
-  branch = "master"
   digest = "1:739c9ec359b9f06cf0fd0cd40dfb609340225956935595625419ed5e414f345a"
   name = "github.com/Bowery/prompt"
   packages = ["."]
@@ -285,13 +284,6 @@
   revision = "a6029d17e101ac1594adafea9e63fd8c988a8701"
   version = "v1.0.12"
 
-[[projects]]
-  digest = "1:274f67cb6fed9588ea2521ecdac05a6d62a8c51c074c1fccc6a49a40ba80e925"
-  name = "gopkg.in/satori/go.uuid.v1"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
-  version = "v1.2.0"
 
 [[projects]]
   digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
@@ -321,7 +313,6 @@
     "github.com/spf13/pflag",
     "github.com/spf13/viper",
     "gopkg.in/h2non/gock.v1",
-    "gopkg.in/satori/go.uuid.v1",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,6 +50,14 @@
   version = "v1.4.7"
 
 [[projects]]
+  digest = "1:bed9d72d596f94e65fff37f4d6c01398074a6bb1c3f3ceff963516bd01db6ff5"
+  name = "github.com/gofrs/uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "6b08a5c5172ba18946672b49749cde22873dd7c2"
+  version = "v3.2.0"
+
+[[projects]]
   branch = "master"
   digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
   name = "github.com/google/go-querystring"
@@ -302,6 +310,7 @@
     "github.com/blang/semver",
     "github.com/davecgh/go-spew/spew",
     "github.com/dghubble/sling",
+    "github.com/gofrs/uuid",
     "github.com/jawher/mow.cli",
     "github.com/lib/pq",
     "github.com/mitchellh/go-homedir",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -54,10 +54,6 @@
   version = "1.0.4"
 
 [[constraint]]
-  name = "gopkg.in/satori/go.uuid.v1"
-  version = "1.1.0"
-
-[[constraint]]
   name = "github.com/gofrs/uuid"
   version = "3.2.0"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -58,6 +58,10 @@
   version = "1.1.0"
 
 [[constraint]]
+  name = "github.com/gofrs/uuid"
+  version = "3.2.0"
+
+[[constraint]]
   name = "github.com/nbio/st"
   branch = "master"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,8 +26,8 @@
 
 
 [[constraint]]
-  branch = "master"
   name = "github.com/Bowery/prompt"
+  revision = "8a1d5376df1cbec3468f2138fecc44dd8b48e342"
 
 [[constraint]]
   name = "github.com/DiSiqueira/GoTree"

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ deps: ## Update dependencies to latest version
 .PHONY: test
 test: ## Ensure that code matchs best practices and run tests
 	staticcheck ./...
-	go test -v ./pkg/conch ./pkg/util ./pkg/config
+	go test -v ./pkg/conch ./pkg/util ./pkg/config ./pkg/conch/uuid
 
 .PHONY: tools
 tools: ## Download and install all dev/code tools

--- a/pkg/cmd/corpus/main.go
+++ b/pkg/cmd/corpus/main.go
@@ -12,12 +12,12 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	_ "github.com/lib/pq"
 	homedir "github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 var FailedCount = 0

--- a/pkg/cmd/corpus/root.go
+++ b/pkg/cmd/corpus/root.go
@@ -10,12 +10,12 @@ import (
 	"fmt"
 
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/joyent/conch-shell/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 var (

--- a/pkg/cmd/tester/root.go
+++ b/pkg/cmd/tester/root.go
@@ -10,12 +10,12 @@ import (
 	"fmt"
 
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/joyent/conch-shell/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 const (

--- a/pkg/cmd/tester/tester.go
+++ b/pkg/cmd/tester/tester.go
@@ -17,12 +17,12 @@ import (
 	"time"
 
 	"github.com/dghubble/sling"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	_ "github.com/lib/pq"
 	homedir "github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 var FailedCount = 0

--- a/pkg/commands/admin/main.go
+++ b/pkg/commands/admin/main.go
@@ -15,8 +15,8 @@ import (
 	gotree "github.com/DiSiqueira/GoTree"
 	"github.com/jawher/mow.cli"
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/joyent/conch-shell/pkg/util"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func listAllUsers(app *cli.Cmd) {

--- a/pkg/commands/devices/devices.go
+++ b/pkg/commands/devices/devices.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/jawher/mow.cli"
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/joyent/conch-shell/pkg/util"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 const extendedDeviceTemplate = `

--- a/pkg/commands/global/init.go
+++ b/pkg/commands/global/init.go
@@ -11,8 +11,8 @@ package global
 
 import (
 	"github.com/jawher/mow.cli"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/joyent/conch-shell/pkg/util"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 // GdcUUID is the UUID of the global datacenter provided by the user

--- a/pkg/commands/global/rack.go
+++ b/pkg/commands/global/rack.go
@@ -13,14 +13,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/jawher/mow.cli"
-	"github.com/joyent/conch-shell/pkg/conch"
-	"github.com/joyent/conch-shell/pkg/util"
-	uuid "gopkg.in/satori/go.uuid.v1"
 	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
+
+	"github.com/jawher/mow.cli"
+	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
+	"github.com/joyent/conch-shell/pkg/util"
 )
 
 func displayOneGlobalRack(r conch.GlobalRack) {

--- a/pkg/commands/global/room.go
+++ b/pkg/commands/global/room.go
@@ -13,8 +13,8 @@ import (
 	"fmt"
 	"github.com/jawher/mow.cli"
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/joyent/conch-shell/pkg/util"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func roomGetAll(app *cli.Cmd) {

--- a/pkg/commands/hardware/hardware.go
+++ b/pkg/commands/hardware/hardware.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/jawher/mow.cli"
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/joyent/conch-shell/pkg/util"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 const singleHWPTemplate = `

--- a/pkg/commands/hardware/init.go
+++ b/pkg/commands/hardware/init.go
@@ -12,8 +12,8 @@ import (
 	"errors"
 
 	"github.com/jawher/mow.cli"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/joyent/conch-shell/pkg/util"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 // ProductUUID is the UUID of the hardware product we're looking at, as

--- a/pkg/commands/profile/profile.go
+++ b/pkg/commands/profile/profile.go
@@ -15,9 +15,9 @@ import (
 	"github.com/Bowery/prompt"
 	"github.com/jawher/mow.cli"
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/joyent/conch-shell/pkg/config"
 	"github.com/joyent/conch-shell/pkg/util"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func newProfile(app *cli.Cmd) {

--- a/pkg/commands/validation/init.go
+++ b/pkg/commands/validation/init.go
@@ -9,8 +9,8 @@ package validation
 
 import (
 	"github.com/jawher/mow.cli"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/joyent/conch-shell/pkg/util"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 var validationUUID uuid.UUID

--- a/pkg/commands/validation/state.go
+++ b/pkg/commands/validation/state.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/jawher/mow.cli"
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/joyent/conch-shell/pkg/util"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 type validationStates []conch.ValidationState

--- a/pkg/commands/workspaces/init.go
+++ b/pkg/commands/workspaces/init.go
@@ -13,8 +13,8 @@ import (
 	"fmt"
 
 	"github.com/jawher/mow.cli"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/joyent/conch-shell/pkg/util"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 // WorkspaceUUID is the UUID of the workspace we're looking at, as gathered by

--- a/pkg/commands/workspaces/user.go
+++ b/pkg/commands/workspaces/user.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/jawher/mow.cli"
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/joyent/conch-shell/pkg/util"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func addUser(app *cli.Cmd) {

--- a/pkg/commands/workspaces/workspaces.go
+++ b/pkg/commands/workspaces/workspaces.go
@@ -19,8 +19,8 @@ import (
 	gotree "github.com/DiSiqueira/GoTree"
 	"github.com/jawher/mow.cli"
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/joyent/conch-shell/pkg/util"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 type rackAssignedSlot struct {

--- a/pkg/conch/auth.go
+++ b/pkg/conch/auth.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	uuid "gopkg.in/satori/go.uuid.v1"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 )
 
 func (c *Conch) RevokeUserTokensAndLogins(user string) error {

--- a/pkg/conch/devices.go
+++ b/pkg/conch/devices.go
@@ -12,7 +12,7 @@ import (
 	"net/url"
 	"sort"
 
-	uuid "gopkg.in/satori/go.uuid.v1"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 )
 
 // GetDevice returns a Device given a specific serial/id
@@ -46,7 +46,7 @@ func (c *Conch) GetExtendedDevice(serial string) (ed ExtendedDevice, err error) 
 	/***********/
 
 	var role GlobalRackRole
-	if !uuid.Equal(d.Location.Rack.RoleID, uuid.UUID{}) {
+	if !d.Location.Rack.RoleID.IsZero() {
 		role, err = c.GetGlobalRackRole(d.Location.Rack.RoleID)
 		if err != nil {
 			return ed, err

--- a/pkg/conch/devices_test.go
+++ b/pkg/conch/devices_test.go
@@ -7,11 +7,12 @@
 package conch_test
 
 import (
+	"testing"
+
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/nbio/st"
 	"gopkg.in/h2non/gock.v1"
-	uuid "gopkg.in/satori/go.uuid.v1"
-	"testing"
 )
 
 func TestDevices(t *testing.T) {

--- a/pkg/conch/global_datacenter.go
+++ b/pkg/conch/global_datacenter.go
@@ -9,7 +9,7 @@ package conch
 import (
 	"net/url"
 
-	uuid "gopkg.in/satori/go.uuid.v1"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 )
 
 func (c *Conch) GetDatacenters() ([]Datacenter, error) {

--- a/pkg/conch/global_datacenter_rack.go
+++ b/pkg/conch/global_datacenter_rack.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"net/url"
 
-	uuid "gopkg.in/satori/go.uuid.v1"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 )
 
 // GetGlobalRacks fetches a list of all racks in the global domain

--- a/pkg/conch/global_datacenter_rack_layout.go
+++ b/pkg/conch/global_datacenter_rack_layout.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"net/url"
 
-	uuid "gopkg.in/satori/go.uuid.v1"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 )
 
 // GetGlobalRackLayoutSlots fetches a list of all rack layouts in the global domain

--- a/pkg/conch/global_datacenter_rack_layout_test.go
+++ b/pkg/conch/global_datacenter_rack_layout_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/nbio/st"
 	"gopkg.in/h2non/gock.v1"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func TestGlobalRackLayoutSlotErrors(t *testing.T) {

--- a/pkg/conch/global_datacenter_rack_role.go
+++ b/pkg/conch/global_datacenter_rack_role.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"net/url"
 
-	uuid "gopkg.in/satori/go.uuid.v1"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 )
 
 // GetGlobalRackRoles fetches a list of all rack roles in the global domain

--- a/pkg/conch/global_datacenter_rack_role_test.go
+++ b/pkg/conch/global_datacenter_rack_role_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/nbio/st"
 	"gopkg.in/h2non/gock.v1"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func TestGlobalRackRoleErrors(t *testing.T) {

--- a/pkg/conch/global_datacenter_rack_test.go
+++ b/pkg/conch/global_datacenter_rack_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/nbio/st"
 	"gopkg.in/h2non/gock.v1"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func TestGlobalRackErrors(t *testing.T) {

--- a/pkg/conch/global_datacenter_room.go
+++ b/pkg/conch/global_datacenter_room.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"net/url"
 
-	uuid "gopkg.in/satori/go.uuid.v1"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 )
 
 // GetGlobalRooms fetches a list of all rooms in the global domain

--- a/pkg/conch/global_datacenter_room_test.go
+++ b/pkg/conch/global_datacenter_room_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/nbio/st"
 	"gopkg.in/h2non/gock.v1"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func TestGlobalRoomErrors(t *testing.T) {

--- a/pkg/conch/global_datacenter_test.go
+++ b/pkg/conch/global_datacenter_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/nbio/st"
 	"gopkg.in/h2non/gock.v1"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func TestDatacenterErrors(t *testing.T) {

--- a/pkg/conch/hardware.go
+++ b/pkg/conch/hardware.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	uuid "gopkg.in/satori/go.uuid.v1"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 )
 
 // GetHardwareProduct fetches a single hardware product via

--- a/pkg/conch/hardware_test.go
+++ b/pkg/conch/hardware_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/nbio/st"
 	"gopkg.in/h2non/gock.v1"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func TestHardwareErrors(t *testing.T) {

--- a/pkg/conch/relays_test.go
+++ b/pkg/conch/relays_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/nbio/st"
 	"gopkg.in/h2non/gock.v1"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func TestRelayErrors(t *testing.T) {

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/joyent/conch-shell/pkg/pgtime"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 // ValidationReport vars provide an abstraction to make sense of the 'status'

--- a/pkg/conch/user.go
+++ b/pkg/conch/user.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"net/url"
 
-	uuid "gopkg.in/satori/go.uuid.v1"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 )
 
 func (c *Conch) GetMyTokens() (UserTokens, error) {

--- a/pkg/conch/uuid/uuid.go
+++ b/pkg/conch/uuid/uuid.go
@@ -16,18 +16,6 @@ type UUID struct {
 	uuid gofrs.UUID
 }
 
-func (u UUID) String() string {
-	return u.uuid.String()
-}
-
-func (u UUID) Equal(u2 UUID) bool {
-	return u.String() == u2.String()
-}
-
-func (u UUID) IsZero() bool {
-	return u.uuid == gofrs.UUID{}
-}
-
 func NewV4() UUID {
 	u, _ := gofrs.NewV4()
 	return UUID{
@@ -37,6 +25,33 @@ func NewV4() UUID {
 
 func New() UUID {
 	return UUID{}
+}
+
+func (u UUID) String() string {
+	return u.uuid.String()
+}
+
+func FromString(str string) (UUID, error) {
+	u, err := gofrs.FromString(str)
+	if err != nil {
+		return New(), err
+	}
+	return UUID{
+		uuid: u,
+	}, nil
+}
+
+func (u UUID) Equal(u2 UUID) bool {
+	return u.String() == u2.String()
+}
+
+// For satori backcompat BUG(sungo)
+func Equal(u UUID, u2 UUID) bool {
+	return u.Equal(u2)
+}
+
+func (u UUID) IsZero() bool {
+	return u.uuid == gofrs.UUID{}
 }
 
 func (u UUID) MarshalJSON() ([]byte, error) {

--- a/pkg/conch/uuid/uuid.go
+++ b/pkg/conch/uuid/uuid.go
@@ -1,0 +1,56 @@
+// Copyright Joyent, Inc.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package uuid
+
+import (
+	"encoding/json"
+
+	gofrs "github.com/gofrs/uuid"
+)
+
+type UUID struct {
+	uuid gofrs.UUID
+}
+
+func (u UUID) String() string {
+	return u.uuid.String()
+}
+
+func (u UUID) Equal(u2 UUID) bool {
+	return u.String() == u2.String()
+}
+
+func (u UUID) IsZero() bool {
+	return u.uuid == gofrs.UUID{}
+}
+
+func NewV4() UUID {
+	u, _ := gofrs.NewV4()
+	return UUID{
+		uuid: u,
+	}
+}
+
+func New() UUID {
+	return UUID{}
+}
+
+func (u UUID) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + u.String() + "\""), nil
+}
+
+func (u *UUID) UnmarshalJSON(b []byte) error {
+	var frs gofrs.UUID
+
+	if err := json.Unmarshal(b, &frs); err != nil {
+		return err
+	}
+
+	u.uuid = frs
+
+	return nil
+}

--- a/pkg/conch/uuid/uuid_test.go
+++ b/pkg/conch/uuid/uuid_test.go
@@ -1,0 +1,53 @@
+package uuid_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
+	"github.com/nbio/st"
+)
+
+func TestUUID(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		u := uuid.New()
+		st.Expect(t, u, uuid.UUID{})
+		st.Expect(t, u.IsZero(), true)
+		st.Expect(t, u.Equal(u), true)
+	})
+
+	t.Run("V4", func(t *testing.T) {
+		u2 := uuid.NewV4()
+		st.Reject(t, u2, uuid.UUID{})
+		st.Expect(t, u2.IsZero(), false)
+
+		u := uuid.New()
+		st.Expect(t, u.Equal(u2), false)
+	})
+
+	t.Run("MarshalJSON", func(t *testing.T) {
+		u := uuid.NewV4()
+		j, err := json.Marshal(u)
+
+		st.Expect(t, err, nil)
+		st.Expect(t, string(j), "\""+u.String()+"\"")
+	})
+
+	t.Run("UnmarshalJSON Round trip", func(t *testing.T) {
+		var u2 uuid.UUID
+		u := uuid.NewV4()
+
+		j, err := json.Marshal(u)
+		st.Expect(t, err, nil)
+		st.Expect(t, string(j), "\""+u.String()+"\"")
+
+		err = json.Unmarshal(j, &u2)
+		st.Expect(t, err, nil)
+
+		st.Expect(t, u, u2)
+		st.Expect(t, u.String(), u2.String())
+		st.Expect(t, u2.IsZero(), false)
+		st.Expect(t, u.Equal(u2), true)
+	})
+
+}

--- a/pkg/conch/uuid/uuid_test.go
+++ b/pkg/conch/uuid/uuid_test.go
@@ -25,6 +25,17 @@ func TestUUID(t *testing.T) {
 		st.Expect(t, u.Equal(u2), false)
 	})
 
+	t.Run("FromString", func(t *testing.T) {
+		u := uuid.NewV4()
+		str := u.String()
+
+		u2, err := uuid.FromString(str)
+		st.Expect(t, err, nil)
+		st.Expect(t, u, u2)
+		st.Expect(t, u.String(), u2.String())
+
+	})
+
 	t.Run("MarshalJSON", func(t *testing.T) {
 		u := uuid.NewV4()
 		j, err := json.Marshal(u)

--- a/pkg/conch/validations_test.go
+++ b/pkg/conch/validations_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/nbio/st"
 	"gopkg.in/h2non/gock.v1"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func TestValidationErrors(t *testing.T) {

--- a/pkg/conch/workspaces.go
+++ b/pkg/conch/workspaces.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"net/url"
 
-	uuid "gopkg.in/satori/go.uuid.v1"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 )
 
 // GetWorkspaceRacks fetchest the list of racks for a workspace, via

--- a/pkg/conch/workspaces_test.go
+++ b/pkg/conch/workspaces_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/nbio/st"
 	"gopkg.in/h2non/gock.v1"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func TestWorkspaceErrors(t *testing.T) {

--- a/pkg/config/main.go
+++ b/pkg/config/main.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	"github.com/joyent/conch-shell/pkg/conch"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 	"github.com/joyent/conch-shell/pkg/config/obfuscate"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 const (

--- a/pkg/util/magic_ids.go
+++ b/pkg/util/magic_ids.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"regexp"
 
-	uuid "gopkg.in/satori/go.uuid.v1"
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
 )
 
 // MagicWorkspaceID takes a string and tries to find a valid UUID. If the


### PR DESCRIPTION
All UUID work is moved into a conch specific library which wraps gofrs/uuid. This gives us the ability to swap out UUID implementations eventually while picking up bug fixes and the like from the gofrs fork of satori/uuid

While not a dependency-free implementation, for now, this closes #292