### PR TITLE
Implement rack and device phases

### DIFF
--- a/pkg/commands/devices/devices.go
+++ b/pkg/commands/devices/devices.go
@@ -24,6 +24,8 @@ Serial: {{ .ID }}
 Hostname: {{.Hostname }}
 Asset Tag: {{ .AssetTag }}
 Health: {{ .Health }}
+Phase: {{ .Phase }}
+
 System UUID: {{ .SystemUUID }}{{ if .IsTritonSetup }}
 Set up for Triton: {{ .TritonSetup.Local }}
   - UUID: {{ .TritonUUID }}{{- end }}{{ if .IsGraduated }}
@@ -624,4 +626,32 @@ func getValidationStates(app *cli.Cmd) {
 		}
 
 	}
+}
+
+func getPhase(app *cli.Cmd) {
+	app.Action = func() {
+		phase, err := util.API.GetDevicePhase(DeviceSerial)
+		if err != nil {
+			util.Bail(err)
+		}
+
+		fmt.Println(phase)
+	}
+}
+
+func setPhase(app *cli.Cmd) {
+	var valueArg = app.StringArg("VALUE", "", "Name of phase")
+
+	app.Spec = "VALUE"
+
+	app.Action = func() {
+		err := util.API.SetDevicePhase(
+			DeviceSerial,
+			*valueArg,
+		)
+		if err != nil {
+			util.Bail(err)
+		}
+	}
+
 }

--- a/pkg/commands/devices/init.go
+++ b/pkg/commands/devices/init.go
@@ -233,6 +233,25 @@ func Init(app *cli.Cli) {
 					)
 				},
 			)
+
+			cmd.Command(
+				"phase",
+				"Get/set the phase for a single device",
+				func(cmd *cli.Cmd) {
+					cmd.Command(
+						"get",
+						"Get the device's phase",
+						getPhase,
+					)
+
+					cmd.Command(
+						"set",
+						"Set the device's phase",
+						setPhase,
+					)
+				},
+			)
+
 		},
 	)
 }

--- a/pkg/commands/global/init.go
+++ b/pkg/commands/global/init.go
@@ -33,6 +33,103 @@ var GLayoutUUID uuid.UUID
 // Init loads up the commands
 func Init(app *cli.Cli) {
 	app.Command(
+		"racks rks",
+		"Operate on all racks",
+		func(cmd *cli.Cmd) {
+			cmd.Before = util.BuildAPIAndVerifyLogin
+			cmd.Command(
+				"get",
+				"Get all racks",
+				rackGetAll,
+			)
+
+			cmd.Command(
+				"create",
+				"Create a rack",
+				rackCreate,
+			)
+		},
+	)
+
+	app.Command(
+		"rack rk",
+		"Operate on individual racks",
+		func(r *cli.Cmd) {
+			var rackIDStr = r.StringArg("ID", "", "The UUID of the rack")
+
+			r.Spec = "ID"
+			r.Before = func() {
+				util.BuildAPIAndVerifyLogin()
+				id, err := util.MagicGlobalRackID(*rackIDStr)
+				if err != nil {
+					util.Bail(err)
+				}
+				GRackUUID = id
+			}
+
+			r.Command(
+				"get",
+				"Get a rack",
+				rackGet,
+			)
+
+			r.Command(
+				"phase",
+				"Get the rack's phase",
+				rackPhaseGet,
+			)
+
+			r.Command(
+				"set",
+				"Change various settings on a rack",
+				func(cmd *cli.Cmd) {
+					cmd.Command(
+						"phase",
+						"Set a rack's phase",
+						rackPhaseSet,
+					)
+				},
+			)
+
+			r.Command(
+				"delete rm",
+				"Delete a rack",
+				rackDelete,
+			)
+
+			r.Command(
+				"update",
+				"Update a rack",
+				rackUpdate,
+			)
+
+			r.Command(
+				"layout",
+				"Commands for dealing with the rack's layout",
+				func(l *cli.Cmd) {
+					l.Command(
+						"get",
+						"Get the rack's layout",
+						rackLayout,
+					)
+
+					l.Command(
+						"import",
+						"Import a layout for this rack",
+						rackImportLayout,
+					)
+
+					l.Command(
+						"export",
+						"Export the layout for this rack",
+						rackExportLayout,
+					)
+				},
+			)
+		},
+	)
+
+	app.Command(
 		"global system",
 		"Execute commands against objects without concern for workspaces. System admin access is required.",
 		func(cmd *cli.Cmd) {

--- a/pkg/commands/global/rack.go
+++ b/pkg/commands/global/rack.go
@@ -33,6 +33,7 @@ Name: %s
 Role ID: %s
 Serial Number: %s
 Asset Tag: %s
+Phase: %s
 
 Created: %s
 Updated: %s
@@ -44,6 +45,7 @@ Updated: %s
 		r.RoleID.String(),
 		r.SerialNumber,
 		r.AssetTag,
+		r.Phase,
 		util.TimeStr(r.Created),
 		util.TimeStr(r.Updated),
 	)
@@ -422,5 +424,34 @@ func rackImportLayout(cmd *cli.Cmd) {
 			}
 		}
 
+	}
+}
+
+func rackPhaseGet(cmd *cli.Cmd) {
+	cmd.Action = func() {
+		phase, err := util.API.GetRackPhase(GRackUUID)
+		if err != nil {
+			util.Bail(err)
+		}
+		fmt.Println(phase)
+	}
+}
+
+func rackPhaseSet(cmd *cli.Cmd) {
+	var (
+		valueArg   = cmd.StringArg("PHASE", "", "The desired phase")
+		devicesOpt = cmd.BoolOpt("devices-also", false, "Also set every device in the rack to the same phase")
+	)
+
+	cmd.Spec = "PHASE [OPTIONS]"
+	cmd.Action = func() {
+		err := util.API.SetRackPhase(
+			GRackUUID,
+			*valueArg,
+			*devicesOpt,
+		)
+		if err != nil {
+			util.Bail(err)
+		}
 	}
 }

--- a/pkg/commands/workspaces/workspaces.go
+++ b/pkg/commands/workspaces/workspaces.go
@@ -301,12 +301,14 @@ Datacenter: %s
 Name: %s
 Role: %s
 Rack ID: %s
+Phase: %s
 `,
 			workspace.Name,
 			rack.Datacenter,
 			rack.Name,
 			rack.Role,
 			rack.ID,
+			rack.Phase,
 		)
 
 		fmt.Println()
@@ -323,6 +325,7 @@ Rack ID: %s
 			"Vendor",
 			"Occupied By",
 			"Health",
+			"Phase",
 		})
 
 		for _, slot := range rack.Slots {
@@ -361,6 +364,7 @@ Rack ID: %s
 				slot.Vendor,
 				occupantID,
 				occupantHealth,
+				slot.Occupant.Phase,
 			})
 
 		}

--- a/pkg/conch/devices.go
+++ b/pkg/conch/devices.go
@@ -247,3 +247,20 @@ func (c *Conch) SubmitDeviceReport(serial string, report string) (state Validati
 	_, err = c.httpDo(req, &state)
 	return state, err
 }
+
+func (c *Conch) GetDevicePhase(serial string) (string, error) {
+	ret := struct {
+		DeviceID string `json:"id"`
+		Phase    string `json:"phase"`
+	}{}
+
+	return ret.Phase, c.get("/device/"+url.PathEscape(serial)+"/phase", &ret)
+}
+
+func (c *Conch) SetDevicePhase(serial string, phase string) error {
+	data := struct {
+		Phase string `json:"phase"`
+	}{phase}
+
+	return c.post("/device/"+url.PathEscape(serial)+"/phase", data, nil)
+}

--- a/pkg/conch/devices_test.go
+++ b/pkg/conch/devices_test.go
@@ -121,4 +121,21 @@ func TestDevices(t *testing.T) {
 		st.Expect(t, ret, conch.ValidationState{})
 	})
 
+	t.Run("GetDevicePhase", func(t *testing.T) {
+		serial := "test"
+		gock.New(API.BaseURL).Get("/device/" + serial + "/phase").Reply(400).JSON(ErrApi)
+
+		ret, err := API.GetDevicePhase(serial)
+		st.Expect(t, err, ErrApiUnpacked)
+		st.Expect(t, ret, "")
+	})
+
+	t.Run("SetDevicePhase", func(t *testing.T) {
+		serial := "test"
+		gock.New(API.BaseURL).Post("/device/" + serial + "/phase").Reply(400).JSON(ErrApi)
+
+		err := API.SetDevicePhase(serial, "production")
+		st.Expect(t, err, ErrApiUnpacked)
+	})
+
 }

--- a/pkg/conch/rack.go
+++ b/pkg/conch/rack.go
@@ -1,0 +1,32 @@
+// Copyright Joyent, Inc.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package conch
+
+import (
+	"net/url"
+
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
+)
+
+func (c *Conch) SetRackPhase(id uuid.UUID, phase string, withDevices bool) error {
+	data := struct {
+		Phase string `json:"phase"`
+	}{phase}
+	escaped := url.PathEscape(id.String())
+
+	url := "/rack/" + escaped + "/phase"
+	if !withDevices {
+		url = url + "?rack_only=1"
+	}
+
+	return c.post(url, data, nil)
+}
+
+func (c *Conch) GetRackPhase(id uuid.UUID) (string, error) {
+	r, err := c.GetGlobalRack(id)
+	return r.Phase, err
+}

--- a/pkg/conch/rack_test.go
+++ b/pkg/conch/rack_test.go
@@ -1,0 +1,46 @@
+// Copyright Joyent, Inc.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package conch_test
+
+import (
+	"testing"
+
+	"github.com/joyent/conch-shell/pkg/conch/uuid"
+	"github.com/nbio/st"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestRackErrors(t *testing.T) {
+	gock.Flush()
+	defer gock.Flush()
+
+	t.Run("SetRackPhase", func(t *testing.T) {
+		id := uuid.NewV4()
+
+		gock.New(API.BaseURL).Post("/rack/" + id.String() + "/phase").
+			Reply(400).JSON(ErrApi)
+
+		err := API.SetRackPhase(id, "wat", true)
+		st.Expect(t, err, ErrApiUnpacked)
+
+		gock.New(API.BaseURL).Post("/rack/"+id.String()+"/phase").
+			MatchParam("rack_only", "1").Reply(400).JSON(ErrApi)
+
+		err = API.SetRackPhase(id, "wat", false)
+		st.Expect(t, err, ErrApiUnpacked)
+	})
+
+	t.Run("GetRackPhase", func(t *testing.T) {
+		id := uuid.NewV4()
+
+		gock.New(API.BaseURL).Get("/rack/" + id.String()).Reply(400).JSON(ErrApi)
+
+		ret, err := API.GetRackPhase(id)
+		st.Expect(t, err, ErrApiUnpacked)
+		st.Expect(t, ret, "")
+	})
+}

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -102,6 +102,7 @@ type Device struct {
 	Disks                 []Disk             `json:"disks"`
 	RackUnitStart         int                `json:"rack_unit_start`
 	RackID                uuid.UUID          `json:"rack_id"`
+	Phase                 string             `json:"phase"`
 }
 
 type Devices []Device
@@ -170,6 +171,7 @@ type GlobalRack struct {
 	RoleID           uuid.UUID `json:"role"`
 	SerialNumber     string    `json:"serial_number"`
 	AssetTag         string    `json:"asset_tag"`
+	Phase            string    `json:"phase"`
 }
 
 // GlobalRackLayoutSlot represents an individual rack layout entry
@@ -349,6 +351,7 @@ type Rack struct {
 	Slots        RackSlots `json:"slots,omitempty"`
 	SerialNumber string    `json:"serial_number"`
 	AssetTag     string    `json:"asset_tag"`
+	Phase        string    `json:"phase"`
 }
 
 // RackSlot represents a physical slot in a physical Rack

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -291,6 +291,7 @@ func DisplayDevices(devices []conch.Device, fullOutput bool) (err error) {
 				Health    string    `json:"health"`
 				Graduated time.Time `json:"graduated"`
 				Validated time.Time `json:"validated"`
+				Phase     string    `json:"phase"`
 			}{
 				d.ID,
 				d.AssetTag,
@@ -299,6 +300,7 @@ func DisplayDevices(devices []conch.Device, fullOutput bool) (err error) {
 				d.Health,
 				d.Graduated,
 				d.Validated,
+				d.Phase,
 			})
 		}
 
@@ -319,6 +321,7 @@ func DisplayDevices(devices []conch.Device, fullOutput bool) (err error) {
 			"Health",
 			"Validated",
 			"Graduated",
+			"Phase",
 		})
 	} else {
 		table.SetHeader([]string{
@@ -329,6 +332,7 @@ func DisplayDevices(devices []conch.Device, fullOutput bool) (err error) {
 			"Health",
 			"Validated",
 			"Graduated",
+			"Phase",
 		})
 	}
 
@@ -358,6 +362,7 @@ func DisplayDevices(devices []conch.Device, fullOutput bool) (err error) {
 				d.Health,
 				validated,
 				graduated,
+				d.Phase,
 			})
 		} else {
 			table.Append([]string{
@@ -368,6 +373,7 @@ func DisplayDevices(devices []conch.Device, fullOutput bool) (err error) {
 				d.Health,
 				validated,
 				graduated,
+				d.Phase,
 			})
 		}
 	}


### PR DESCRIPTION
The device and rack phases are visible now in their text and json views. 

New Commands:
* `device :id phase get`
* `device :id phase set :phase`
* `rack :id phase`
* `rack :id set phase :phase`. adding `--also-devices` will change the phase of all the devices in the rack at the same time

Altered Commands:
* All of the commands under `global rack` and `global racks` are now available as just `rack` and `racks`, respectively. The `global` versions will be removed eventually but there is no explicit timeframe yet

Closes #282 