### PR TITLE
Handle deactivated validations

### DIFF
--- a/pkg/commands/validation/plan.go
+++ b/pkg/commands/validation/plan.go
@@ -65,19 +65,30 @@ func getValidationPlan(app *cli.Cmd) {
 }
 
 func showValidationPlanValidations(app *cli.Cmd) {
+	var showDeactivated = app.BoolOpt("deactivated", false, "Show deactivated (old) versions of validations")
 
 	app.Action = func() {
-		var validations validations
 		validations, err := util.API.GetValidationPlanValidations(validationPlanUUID)
 		if err != nil {
 			util.Bail(err)
+		}
+
+		if !*showDeactivated {
+			v := make(conch.Validations, 0)
+			for _, validation := range validations {
+				if validation.Deactivated.IsZero() {
+					v = append(v, validation)
+				}
+			}
+			validations = v
 		}
 
 		if util.JSON {
 			util.JSONOut(validations)
 			return
 		}
-		validations.renderTable()
+
+		renderTableValidations(validations, *showDeactivated)
 	}
 }
 

--- a/pkg/conch/structs.go
+++ b/pkg/conch/structs.go
@@ -453,6 +453,20 @@ type Validation struct {
 	Description string    `json:"description"`
 	Created     time.Time `json:"created"`
 	Updated     time.Time `json:"updated"`
+	Deactivated time.Time `json:"deactivated"`
+}
+
+type Validations []Validation
+
+func (v Validations) Len() int {
+	return len(v)
+}
+func (v Validations) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
+func (v Validations) Less(i, j int) bool {
+	return strings.ToLower(v[i].Name) < strings.ToLower(v[j].Name)
 }
 
 // ValidationPlan represents an organized association of Validations

--- a/pkg/conch/validations.go
+++ b/pkg/conch/validations.go
@@ -14,8 +14,8 @@ import (
 
 // GetValidations returns the contents of /validation, getting the list of all
 // validations loaded in the system
-func (c *Conch) GetValidations() ([]Validation, error) {
-	validations := make([]Validation, 0)
+func (c *Conch) GetValidations() (Validations, error) {
+	validations := make(Validations, 0)
 	return validations, c.get("/validation", &validations)
 }
 func (c *Conch) GetValidation(id fmt.Stringer) (v Validation, err error) {
@@ -44,9 +44,9 @@ func (c *Conch) GetValidationPlan(
 // GetValidationPlanValidations gets the list of validations associated with a validation plan
 func (c *Conch) GetValidationPlanValidations(
 	validationPlanUUID fmt.Stringer,
-) ([]Validation, error) {
+) (Validations, error) {
 
-	validations := make([]Validation, 0)
+	validations := make(Validations, 0)
 	return validations, c.get(
 		"/validation_plan/"+url.PathEscape(validationPlanUUID.String())+"/validation",
 		&validations,

--- a/pkg/conch/validations_test.go
+++ b/pkg/conch/validations_test.go
@@ -24,7 +24,7 @@ func TestValidationErrors(t *testing.T) {
 		gock.New(API.BaseURL).Get(url).Reply(400).JSON(ErrApi)
 		ret, err := API.GetValidations()
 		st.Expect(t, err, ErrApiUnpacked)
-		st.Expect(t, ret, []conch.Validation{})
+		st.Expect(t, ret, conch.Validations{})
 	})
 
 	t.Run("GetValidationPlans", func(t *testing.T) {


### PR DESCRIPTION
In the places we display lists of validations, sort them, hide deactivated validations by default, and allow the user to show deactivated validations if desired

Closes #303 
Closes #259 