### PR TITLE
bump minimum required API version to 2.30

### DIFF
--- a/pkg/conch/conch.go
+++ b/pkg/conch/conch.go
@@ -32,7 +32,7 @@ type omit bool
 
 const (
 	// MinimumAPIVersion sets the earliest API version that we support.
-	MinimumAPIVersion  = "2.27.0"
+	MinimumAPIVersion  = "2.30.0"
 	BreakingAPIVersion = "3.0.0"
 )
 


### PR DESCRIPTION
The rack assignment changes added yesterday require API v2.30 and was missed in that PR