### PR TITLE
remove body for POST to hardware vendor

### DIFF
--- a/pkg/conch/hardware.go
+++ b/pkg/conch/hardware.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"strings"
 
 	"github.com/joyent/conch-shell/pkg/conch/uuid"
 )
@@ -132,13 +133,9 @@ func (c *Conch) SaveHardwareVendor(v *HardwareVendor) error {
 		return ErrBadInput
 	}
 
-	out := struct {
-		Name string `json:"name"`
-	}{v.Name}
-
-	return c.post(
+	return c.postString(
 		"/hardware_vendor/"+url.PathEscape(v.Name),
-		out,
+		strings.NewReader(""),
 		&v,
 	)
 }

--- a/pkg/conch/sling.go
+++ b/pkg/conch/sling.go
@@ -238,6 +238,21 @@ func (c *Conch) post(url string, payload interface{}, response interface{}) erro
 	return err
 }
 
+func (c *Conch) postString(url string, body io.Reader, response interface{}) error {
+	req, err := c.sling().New().
+		Post(url).
+		Set("Content-Type", "application/json").
+		Body(body).
+		Request()
+
+	if err != nil {
+		return err
+	}
+
+	_, err = c.httpDo(req, response)
+	return err
+}
+
 func (c *Conch) postNeedsResponse(
 	url string,
 	payload interface{},


### PR DESCRIPTION
Required adding a new method to allow us to send an empty string as an
`application/json` encoded string to the server.