### PR TITLE
enable an (optional) FILE param for `api delete`

### DIFF
--- a/pkg/commands/api/main.go
+++ b/pkg/commands/api/main.go
@@ -48,12 +48,26 @@ func get(cmd *cli.Cmd) {
 }
 
 func deleteAPI(cmd *cli.Cmd) {
-	var cmdArg = cmd.StringArg("CMD", "", "The API path to DELETE. Must *not* include the hostname or port")
-	cmd.Spec = "CMD"
+	var cmdArg = cmd.StringArg("API", "", "The API path to DELETE. Must *not* include the hostname or port")
+	var filePathArg = cmd.StringArg("FILE", "", "Path to a JSON file to use as the request body. '-' indicates STDIN")
+	cmd.Spec = "API [FILE]"
 	cmd.Action = func() {
 		util.JSON = true
 		if *cmdArg != "" {
-			res, err := util.API.RawDelete(*cmdArg)
+			var b []byte
+			if *filePathArg != "" {
+				var err error
+				if *filePathArg == "-" {
+					b, err = ioutil.ReadAll(os.Stdin)
+				} else {
+					b, err = ioutil.ReadFile(*filePathArg)
+				}
+				if err != nil {
+					util.Bail(err)
+				}
+			}
+
+			res, err := util.API.RawDelete(*cmdArg, bytes.NewReader(b))
 			if err != nil {
 				util.Bail(err)
 			}

--- a/pkg/conch/sling.go
+++ b/pkg/conch/sling.go
@@ -271,8 +271,8 @@ func (c *Conch) RawGet(url string) (*http.Response, error) {
 
 // RawDelete allows the user to perform an HTTP DELETE against the API, with the
 // library handling all auth but *not* processing the response.
-func (c *Conch) RawDelete(url string) (*http.Response, error) {
-	req, err := c.sling().New().Delete(url).Request()
+func (c *Conch) RawDelete(url string, body io.Reader) (*http.Response, error) {
+	req, err := c.sling().New().Delete(url).Body(body).Request()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The conch API for deleting rack assignments takes a request body but
there is currently no way to provide that. This enables the raw api
command tree to at least enable that.